### PR TITLE
[seed] tasks P1-T1,P1-T2,P1-T3,P1-T5,P1-T6,P2-T1

### DIFF
--- a/.codex/tasks/4a7d2c19-init-python.md
+++ b/.codex/tasks/4a7d2c19-init-python.md
@@ -1,0 +1,26 @@
+---
+id: 4a7d2c19
+title: "Initialize PEP 621 project"
+role: Coder
+priority: P0
+phase_id: "P1-T1"
+depends_on: []
+acceptance:
+  - "`pyproject.toml` defines a `[project]` table for {PROJECT_SLUG} with name, version, description, authors, and readme using PEP 621 fields."
+  - "`src/{PROJECT_SLUG}/__init__.py` and `tests/` exist so the src layout and baseline test tree are ready."
+  - "`python -m build` completes successfully from the repo root."
+evidence:
+  expected:
+    - "python -m build"
+  artifacts:
+    - "pyproject.toml"
+    - "src/{PROJECT_SLUG}/__init__.py"
+---
+
+## Context
+Set up the minimal Python packaging scaffold so later tasks can add code, configs, and entry points per the roadmap.
+
+## Plan
+- Create `pyproject.toml` with PEP 621 metadata for {PROJECT_SLUG} and build-system config.
+- Add `src/{PROJECT_SLUG}/__init__.py` and ensure `tests/` directory exists.
+- Verify `python -m build` succeeds against the new layout.

--- a/.codex/tasks/7c9e2a15-config-loader.md
+++ b/.codex/tasks/7c9e2a15-config-loader.md
@@ -1,0 +1,29 @@
+---
+id: 7c9e2a15
+title: "Implement config loader"
+role: Coder
+priority: P1
+phase_id: "P2-T1"
+depends_on:
+  - 4a7d2c19
+  - ae56b201
+  - f3a1c5d2
+acceptance:
+  - "Implement a config loader that merges defaults, `{CONFIG_PATH}` contents, and CLI overrides with precedence: defaults < file < flags."
+  - "Support overriding the config path via a CLI option or function argument for tests."
+  - "Unit tests cover precedence scenarios (no file, file only, file plus overrides) and pass with `pytest -q`."
+evidence:
+  expected:
+    - "pytest -q"
+  artifacts:
+    - "src/{PROJECT_SLUG}/config.py"
+    - "tests/config/test_loader.py"
+---
+
+## Context
+Phase 2 introduces configuration management; we need a loader that respects `{CONFIG_PATH}` while allowing CLI flags to take priority per the PRD.
+
+## Plan
+- Define defaults and implement loader functions/classes that read YAML from `{CONFIG_PATH}` when present.
+- Allow callers to override the config path (for CLI flag + testing) and merge inputs with correct precedence.
+- Add targeted pytest coverage verifying precedence logic and ensure the suite passes.

--- a/.codex/tasks/9b3e6d84-entrypoint.md
+++ b/.codex/tasks/9b3e6d84-entrypoint.md
@@ -1,0 +1,28 @@
+---
+id: 9b3e6d84
+title: "Expose console entry point"
+role: Coder
+priority: P0
+phase_id: "P1-T2"
+depends_on:
+  - 4a7d2c19
+acceptance:
+  - "`pyproject.toml` declares a `console_scripts` entry so `{ENTRYPOINT}` resolves to the package's CLI module."
+  - "Editable install (`python -m pip install -e .`) creates a `{ENTRYPOINT}` executable on PATH."
+  - "Running `{ENTRYPOINT} --help` succeeds and prints a placeholder usage message (no stack trace)."
+evidence:
+  expected:
+    - "python -m pip install -e ."
+    - "{ENTRYPOINT} --help"
+  artifacts:
+    - "pyproject.toml"
+    - "src/{PROJECT_SLUG}/cli.py"
+---
+
+## Context
+Ensure the package exposes the `{ENTRYPOINT}` command early so future CLI features can plug into the same executable.
+
+## Plan
+- Update `pyproject.toml` to map `{ENTRYPOINT}` to the CLI module function stub.
+- Provide a minimal CLI callable that emits usage text without failing.
+- Validate editable install places the `{ENTRYPOINT}` script and `--help` runs without errors.

--- a/.codex/tasks/ae56b201-pkg-skeleton.md
+++ b/.codex/tasks/ae56b201-pkg-skeleton.md
@@ -1,0 +1,27 @@
+---
+id: ae56b201
+title: "Create package skeleton"
+role: Coder
+priority: P0
+phase_id: "P1-T3"
+depends_on:
+  - 4a7d2c19
+acceptance:
+  - "`src/{PROJECT_SLUG}/cli.py` defines a `main()` callable that becomes the `{ENTRYPOINT}` target."
+  - "`src/{PROJECT_SLUG}/core/` package exists with `__init__.py` ready for future modules."
+  - "Import checks (`python -c "import {PROJECT_SLUG}; import {PROJECT_SLUG}.cli; import {PROJECT_SLUG}.core"`) succeed."
+evidence:
+  expected:
+    - "python -c \"import {PROJECT_SLUG}; import {PROJECT_SLUG}.cli; import {PROJECT_SLUG}.core\""
+  artifacts:
+    - "src/{PROJECT_SLUG}/cli.py"
+    - "src/{PROJECT_SLUG}/core/__init__.py"
+---
+
+## Context
+Lay down the base modules and namespaces so subsequent tasks can flesh out CLI and core logic without worrying about package wiring.
+
+## Plan
+- Add CLI module with placeholder `main()` returning a non-error status or message.
+- Create `core` package directory with `__init__.py` prepared for future exports.
+- Smoke-test imports to confirm the namespace is wired correctly.

--- a/.codex/tasks/d42c9f70-ruff-config.md
+++ b/.codex/tasks/d42c9f70-ruff-config.md
@@ -1,0 +1,27 @@
+---
+id: d42c9f70
+title: "Add Ruff config"
+role: Coder
+priority: P0
+phase_id: "P1-T5"
+depends_on:
+  - 4a7d2c19
+acceptance:
+  - "`pyproject.toml` (or `.ruff.toml`) configures Ruff with agreed rules for the src layout."
+  - "`ruff check .` passes without diagnostics."
+  - "Add Ruff invocation to developer docs or tooling so contributors know how to lint."
+evidence:
+  expected:
+    - "ruff check ."
+  artifacts:
+    - "pyproject.toml"
+    - "docs or README snippet describing lint command"
+---
+
+## Context
+Introduce linting early to keep style consistent and catch issues before expanding the codebase.
+
+## Plan
+- Configure Ruff via `pyproject.toml` (preferred) with project-appropriate rules and ignores.
+- Ensure lint command covers `src/` and `tests/` directories.
+- Run Ruff and update docs or scripts so contributors can lint reliably.

--- a/.codex/tasks/f3a1c5d2-pytest-src.md
+++ b/.codex/tasks/f3a1c5d2-pytest-src.md
@@ -1,0 +1,27 @@
+---
+id: f3a1c5d2
+title: "Configure pytest src layout"
+role: Coder
+priority: P0
+phase_id: "P1-T6"
+depends_on:
+  - 4a7d2c19
+acceptance:
+  - "`pyproject.toml` (or `pytest.ini`) sets pytest defaults: `-q`, `pythonpath=src`, and any needed ini options."
+  - "A placeholder test (e.g., `tests/test_placeholder.py`) exists so discovery verifies the layout."
+  - "`pytest -q` passes from a clean checkout."
+evidence:
+  expected:
+    - "pytest -q"
+  artifacts:
+    - "pyproject.toml"
+    - "tests/test_placeholder.py"
+---
+
+## Context
+Align pytest with the src/ layout early so later tests run without import friction and CI can execute consistently.
+
+## Plan
+- Add pytest configuration under `pyproject.toml` to point at `src/` and quiet output.
+- Create a minimal placeholder test to assert the harness works.
+- Run pytest to confirm discovery and the config behave as expected.


### PR DESCRIPTION
## Summary
- add six coder task files to bootstrap Phase 1 setup and Phase 2 config work for discripper.

## Acceptance & Evidence
- **P1-T1** (`.codex/tasks/4a7d2c19-init-python.md`)
  - Acceptance: PEP 621 `[project]` metadata, src layout scaffolding, `python -m build` succeeds.
  - Evidence: Expected `python -m build`; artifacts `pyproject.toml`, `src/{PROJECT_SLUG}/__init__.py`.
- **P1-T2** (`.codex/tasks/9b3e6d84-entrypoint.md`)
  - Acceptance: `{ENTRYPOINT}` console script defined, editable install provides script, `--help` runs.
  - Evidence: Expected `python -m pip install -e .`, `{ENTRYPOINT} --help`; artifacts `pyproject.toml`, `src/{PROJECT_SLUG}/cli.py`.
- **P1-T3** (`.codex/tasks/ae56b201-pkg-skeleton.md`)
  - Acceptance: CLI `main()` stub, `core` package ready, imports succeed via smoke test command.
  - Evidence: Expected `python -c "import {PROJECT_SLUG}; import {PROJECT_SLUG}.cli; import {PROJECT_SLUG}.core"`; artifacts `src/{PROJECT_SLUG}/cli.py`, `src/{PROJECT_SLUG}/core/__init__.py`.
- **P1-T5** (`.codex/tasks/d42c9f70-ruff-config.md`)
  - Acceptance: Ruff configured, `ruff check .` clean, lint command documented.
  - Evidence: Expected `ruff check .`; artifacts `pyproject.toml`, lint command documentation snippet.
- **P1-T6** (`.codex/tasks/f3a1c5d2-pytest-src.md`)
  - Acceptance: Pytest defaults set for src layout, placeholder test added, `pytest -q` passes.
  - Evidence: Expected `pytest -q`; artifacts `pyproject.toml`, `tests/test_placeholder.py`.
- **P2-T1** (`.codex/tasks/7c9e2a15-config-loader.md`)
  - Acceptance: Config loader honors precedence `{CONFIG_PATH}` vs flags, override support, tests passing.
  - Evidence: Expected `pytest -q`; artifacts `src/{PROJECT_SLUG}/config.py`, `tests/config/test_loader.py`.


------
https://chatgpt.com/codex/tasks/task_b_68e31b1309708321b9350c489109f940