### PR TITLE
[seed] tasks P1-T1,P1-T2,P1-T3,P1-T5,P1-T6,P2-T1

### DIFF
--- a/.codex/tasks/4a7d2c19-init-python.md
+++ b/.codex/tasks/4a7d2c19-init-python.md
@@ -6,21 +6,25 @@ priority: P0
 phase_id: "P1-T1"
 depends_on: []
 acceptance:
-  - "`pyproject.toml` defines a `[project]` table for {PROJECT_SLUG} with name, version, description, authors, and readme using PEP 621 fields."
-  - "`src/{PROJECT_SLUG}/__init__.py` and `tests/` exist so the src layout and baseline test tree are ready."
-  - "`python -m build` completes successfully from the repo root."
+  - "`pyproject.toml` defines a `[project]` table for `discripper` with name, version, description, authors, and `readme = \"README.md\"`, and configures `hatchling` in `[build-system]`."
+  - "`src/discripper/__init__.py` exists with a module docstring and exported `__all__`, and a `tests/__init__.py` file anchors the `tests/` package."
+  - "`python -m build` completes successfully from the repository root."
 evidence:
   expected:
+    - "pip install -e ."
+    - "ruff check ."
+    - "pytest -q --cov=src --cov-fail-under=80"
     - "python -m build"
   artifacts:
     - "pyproject.toml"
-    - "src/{PROJECT_SLUG}/__init__.py"
+    - "src/discripper/__init__.py"
+    - "tests/__init__.py"
 ---
 
 ## Context
-Set up the minimal Python packaging scaffold so later tasks can add code, configs, and entry points per the roadmap.
+Lay the packaging foundation so future tasks can add console hooks, configuration handling, and implementation modules without reworking project metadata.
 
 ## Plan
-- Create `pyproject.toml` with PEP 621 metadata for {PROJECT_SLUG} and build-system config.
-- Add `src/{PROJECT_SLUG}/__init__.py` and ensure `tests/` directory exists.
-- Verify `python -m build` succeeds against the new layout.
+- Create `pyproject.toml` with PEP 621 metadata for `discripper` and configure `hatchling` as the build backend.
+- Add `src/discripper/__init__.py` exporting a placeholder namespace and create `tests/__init__.py` to enable package-style tests.
+- Run `python -m build` plus the local gates to verify the project builds and tooling succeeds.

--- a/.codex/tasks/7c9e2a15-config-loader.md
+++ b/.codex/tasks/7c9e2a15-config-loader.md
@@ -5,25 +5,29 @@ role: Coder
 priority: P1
 phase_id: "P2-T1"
 depends_on:
-  - 4a7d2c19
-  - ae56b201
+  - 9b3e6d84
+  - d42c9f70
   - f3a1c5d2
 acceptance:
-  - "Implement a config loader that merges defaults, `{CONFIG_PATH}` contents, and CLI overrides with precedence: defaults < file < flags."
-  - "Support overriding the config path via a CLI option or function argument for tests."
-  - "Unit tests cover precedence scenarios (no file, file only, file plus overrides) and pass with `pytest -q`."
+  - "`src/discripper/core/config.py` implements a loader that starts from project defaults, reads `~/.config/discripper.yaml` when present, and merges CLI overrides with precedence defaults < file < overrides."
+  - "`discripper --help` documents a `--config-path` (or similarly named) flag that lets users specify an alternate config file path."
+  - "Unit tests in `tests/test_config.py` cover no-file, file-only, and file-plus-overrides scenarios using temporary paths, and the suite passes with `pytest -q --cov=src --cov-fail-under=80`."
 evidence:
   expected:
-    - "pytest -q"
+    - "pip install -e ."
+    - "ruff check ."
+    - "pytest -q --cov=src --cov-fail-under=80"
+    - "discripper --help"
   artifacts:
-    - "src/{PROJECT_SLUG}/config.py"
-    - "tests/config/test_loader.py"
+    - "src/discripper/core/config.py"
+    - "src/discripper/cli.py"
+    - "tests/test_config.py"
 ---
 
 ## Context
-Phase 2 introduces configuration management; we need a loader that respects `{CONFIG_PATH}` while allowing CLI flags to take priority per the PRD.
+Phase 2 adds real configuration handling so the CLI can honor defaults while letting users override settings via config files and command-line flags.
 
 ## Plan
-- Define defaults and implement loader functions/classes that read YAML from `{CONFIG_PATH}` when present.
-- Allow callers to override the config path (for CLI flag + testing) and merge inputs with correct precedence.
-- Add targeted pytest coverage verifying precedence logic and ensure the suite passes.
+- Implement the configuration loader in `src/discripper/core/config.py`, including YAML parsing and precedence handling aligned with the PRD. 
+- Extend the CLI to expose a `--config-path` flag that feeds into the loader while continuing to support the default at `~/.config/discripper.yaml`.
+- Add comprehensive pytest coverage around precedence scenarios and ensure all local gates succeed.

--- a/.codex/tasks/9b3e6d84-entrypoint.md
+++ b/.codex/tasks/9b3e6d84-entrypoint.md
@@ -7,22 +7,24 @@ phase_id: "P1-T2"
 depends_on:
   - 4a7d2c19
 acceptance:
-  - "`pyproject.toml` declares a `console_scripts` entry so `{ENTRYPOINT}` resolves to the package's CLI module."
-  - "Editable install (`python -m pip install -e .`) creates a `{ENTRYPOINT}` executable on PATH."
-  - "Running `{ENTRYPOINT} --help` succeeds and prints a placeholder usage message (no stack trace)."
+  - "`pyproject.toml` adds a `console_scripts` entry mapping `discripper = discripper.cli:main`."
+  - "`pip install -e .` creates an executable named `discripper` on `PATH` that resolves to the package CLI."
+  - "Running `discripper --help` prints the placeholder usage text without raising an exception."
 evidence:
   expected:
-    - "python -m pip install -e ."
-    - "{ENTRYPOINT} --help"
+    - "pip install -e ."
+    - "ruff check ."
+    - "pytest -q --cov=src --cov-fail-under=80"
+    - "discripper --help"
   artifacts:
     - "pyproject.toml"
-    - "src/{PROJECT_SLUG}/cli.py"
+    - "src/discripper/cli.py"
 ---
 
 ## Context
-Ensure the package exposes the `{ENTRYPOINT}` command early so future CLI features can plug into the same executable.
+Make the command-line entry point available early so downstream tasks can add subcommands and configuration flags against the same executable.
 
 ## Plan
-- Update `pyproject.toml` to map `{ENTRYPOINT}` to the CLI module function stub.
-- Provide a minimal CLI callable that emits usage text without failing.
-- Validate editable install places the `{ENTRYPOINT}` script and `--help` runs without errors.
+- Update `pyproject.toml` to declare `discripper` as a console script targeting `discripper.cli:main`.
+- Implement a minimal `main()` function in `src/discripper/cli.py` that prints usage help and exits cleanly.
+- Verify the local gates and confirm `discripper --help` works after an editable install.

--- a/.codex/tasks/ae56b201-pkg-skeleton.md
+++ b/.codex/tasks/ae56b201-pkg-skeleton.md
@@ -7,21 +7,24 @@ phase_id: "P1-T3"
 depends_on:
   - 4a7d2c19
 acceptance:
-  - "`src/{PROJECT_SLUG}/cli.py` defines a `main()` callable that becomes the `{ENTRYPOINT}` target."
-  - "`src/{PROJECT_SLUG}/core/` package exists with `__init__.py` ready for future modules."
-  - "Import checks (`python -c "import {PROJECT_SLUG}; import {PROJECT_SLUG}.cli; import {PROJECT_SLUG}.core"`) succeed."
+  - "`src/discripper/cli.py` defines a `main()` callable that returns an exit code and will be wired to the console script."
+  - "`src/discripper/core/__init__.py` exists so the `discripper.core` namespace is importable for future modules."
+  - "`python -c \"import discripper; import discripper.cli; import discripper.core\"` succeeds without raising exceptions."
 evidence:
   expected:
-    - "python -c \"import {PROJECT_SLUG}; import {PROJECT_SLUG}.cli; import {PROJECT_SLUG}.core\""
+    - "pip install -e ."
+    - "ruff check ."
+    - "pytest -q --cov=src --cov-fail-under=80"
+    - "python -c \"import discripper; import discripper.cli; import discripper.core\""
   artifacts:
-    - "src/{PROJECT_SLUG}/cli.py"
-    - "src/{PROJECT_SLUG}/core/__init__.py"
+    - "src/discripper/cli.py"
+    - "src/discripper/core/__init__.py"
 ---
 
 ## Context
-Lay down the base modules and namespaces so subsequent tasks can flesh out CLI and core logic without worrying about package wiring.
+Establish the CLI module and core package namespaces so later tasks can focus on business logic rather than scaffolding.
 
 ## Plan
-- Add CLI module with placeholder `main()` returning a non-error status or message.
-- Create `core` package directory with `__init__.py` prepared for future exports.
-- Smoke-test imports to confirm the namespace is wired correctly.
+- Implement a placeholder `main()` function in `src/discripper/cli.py` that coordinates with the console script entry point.
+- Create the `src/discripper/core/` package with `__init__.py` exporting a stub to anchor future components.
+- Run the local gates and a manual import smoke test to confirm the package skeleton is wired correctly.

--- a/.codex/tasks/d42c9f70-ruff-config.md
+++ b/.codex/tasks/d42c9f70-ruff-config.md
@@ -7,21 +7,23 @@ phase_id: "P1-T5"
 depends_on:
   - 4a7d2c19
 acceptance:
-  - "`pyproject.toml` (or `.ruff.toml`) configures Ruff with agreed rules for the src layout."
-  - "`ruff check .` passes without diagnostics."
-  - "Add Ruff invocation to developer docs or tooling so contributors know how to lint."
+  - "`pyproject.toml` configures Ruff under `[tool.ruff]` (and sub-tables) with target version `py311`, src layout includes `src` and `tests`, and enables lint rules agreed for the project."
+  - "`ruff check .` passes without diagnostics on a clean checkout."
+  - "`README.md` (or equivalent developer docs) documents how to run `ruff check .` in the Local Gates section."
 evidence:
   expected:
+    - "pip install -e ."
     - "ruff check ."
+    - "pytest -q --cov=src --cov-fail-under=80"
   artifacts:
     - "pyproject.toml"
-    - "docs or README snippet describing lint command"
+    - "README.md"
 ---
 
 ## Context
-Introduce linting early to keep style consistent and catch issues before expanding the codebase.
+Introduce linting early to keep style consistent, matching the repo's local gates and enabling CI enforcement later.
 
 ## Plan
-- Configure Ruff via `pyproject.toml` (preferred) with project-appropriate rules and ignores.
-- Ensure lint command covers `src/` and `tests/` directories.
-- Run Ruff and update docs or scripts so contributors can lint reliably.
+- Add a Ruff configuration to `pyproject.toml` covering the `src/` and `tests/` directories with the desired target version and rule set.
+- Verify linting succeeds on a clean workspace using the standard command.
+- Update `README.md` (or developer guide) to mention Ruff in the contributor workflow and align with the local gates.

--- a/.codex/tasks/f3a1c5d2-pytest-src.md
+++ b/.codex/tasks/f3a1c5d2-pytest-src.md
@@ -7,21 +7,23 @@ phase_id: "P1-T6"
 depends_on:
   - 4a7d2c19
 acceptance:
-  - "`pyproject.toml` (or `pytest.ini`) sets pytest defaults: `-q`, `pythonpath=src`, and any needed ini options."
-  - "A placeholder test (e.g., `tests/test_placeholder.py`) exists so discovery verifies the layout."
-  - "`pytest -q` passes from a clean checkout."
+  - "`pyproject.toml` (or `pytest.ini`) configures pytest with `pythonpath = [\"src\"]`, default `-q` flag, and coverage settings matching the local gate (`--cov=src --cov-fail-under=80`)."
+  - "`tests/test_placeholder.py` exists and imports `discripper` to prove discovery works with the src layout."
+  - "`pytest -q --cov=src --cov-fail-under=80` succeeds from a clean checkout."
 evidence:
   expected:
-    - "pytest -q"
+    - "pip install -e ."
+    - "ruff check ."
+    - "pytest -q --cov=src --cov-fail-under=80"
   artifacts:
     - "pyproject.toml"
     - "tests/test_placeholder.py"
 ---
 
 ## Context
-Align pytest with the src/ layout early so later tests run without import friction and CI can execute consistently.
+Align pytest with the src/ directory structure so later tests run without path hacks and coverage targets are enforced from day one.
 
 ## Plan
-- Add pytest configuration under `pyproject.toml` to point at `src/` and quiet output.
-- Create a minimal placeholder test to assert the harness works.
-- Run pytest to confirm discovery and the config behave as expected.
+- Add pytest configuration (preferably in `pyproject.toml`) that points to `src/`, sets the quiet flag, and enforces coverage thresholds.
+- Write a simple placeholder test that imports `discripper` to validate discovery against the src layout.
+- Execute the local gates to ensure pytest passes with the configured options.


### PR DESCRIPTION
## Summary
- Updated P1-T1 to lock the PEP 621 metadata, src layout artifacts, and successful build gate.
- Updated P1-T2 to require the `discripper` console script, editable install verification, and CLI help output.
- Updated P1-T3 to document the CLI/core package skeleton and import smoke test.
- Updated P1-T5 to capture the Ruff configuration expectations and documentation touchpoint.
- Updated P1-T6 to enforce pytest src-layout configuration and coverage gating.
- Updated P2-T1 to specify the config loader precedence rules, CLI flag, and coverage-backed tests.

## Evidence Commands
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80
- python -m build (P1-T1)
- discripper --help (P1-T2, P2-T1)
- python -c "import discripper; import discripper.cli; import discripper.core" (P1-T3)


------
https://chatgpt.com/codex/tasks/task_b_68e320ee4094832187e8b19bddb53208