### PR TITLE
Add placeholder CLI entry point script

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -9,7 +9,7 @@
 
 ## Phase 1 – Project Setup & Scaffolding
 - [x] Initialize Python project (PEP 621 `pyproject.toml`, `src/` layout, tests/) (repo builds locally) [#P1-T1]
-- [ ] Add console entry point for `{ENTRYPOINT}` in `pyproject.toml` (entry shows in `pip install -e .`) [#P1-T2]
+- [x] Add console entry point for `{ENTRYPOINT}` in `pyproject.toml` (entry shows in `pip install -e .`) [#P1-T2]
 - [ ] Create package skeleton `src/{PROJECT_SLUG}/cli.py` and `src/{PROJECT_SLUG}/core/__init__.py` (imports succeed) [#P1-T3]
 - [ ] Add `.gitignore` for Python, build, and test artifacts (ignored files confirmed) [#P1-T4]
 - [ ] Add `ruff` config and minimal rule-set in `pyproject.toml` (ruff runs clean) [#P1-T5]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ authors = [{ name = "discripper contributors" }]
 license = { text = "MIT" }
 requires-python = ">=3.10"
 
+[project.scripts]
+discripper = "discripper.cli:main"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 

--- a/src/discripper/cli.py
+++ b/src/discripper/cli.py
@@ -1,0 +1,18 @@
+"""Command-line interface for the discripper tool."""
+
+from __future__ import annotations
+
+import sys
+
+_PLACEHOLDER_USAGE = """discripper CLI (placeholder)\n\nUsage: discripper [options]\n\nThis interface will be implemented in future tasks."""
+
+
+def main() -> int:
+    """Entry point for the console script."""
+
+    print(_PLACEHOLDER_USAGE)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,6 +1,7 @@
 """Smoke tests for the discripper package."""
 
 import discripper
+from discripper import cli
 
 
 def test_version_is_string() -> None:
@@ -8,3 +9,13 @@ def test_version_is_string() -> None:
 
     assert isinstance(discripper.__version__, str)
     assert discripper.__version__ != ""
+
+
+def test_cli_main_prints_placeholder(capsys) -> None:
+    """The CLI main function prints the placeholder usage text."""
+
+    exit_code = cli.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Usage: discripper" in captured.out


### PR DESCRIPTION
## Summary
- declare a `console_scripts` entry mapping `discripper` to `discripper.cli:main`
- add a placeholder CLI `main()` that prints usage text and exits cleanly
- extend the smoke test suite to cover the CLI placeholder behaviour

## Testing
- pip install -e .
- ruff check .
- PYTHONPATH=src pytest -q --cov=src --cov-fail-under=80
- discripper --help

Task: .codex/tasks/9b3e6d84-entrypoint.md

------
https://chatgpt.com/codex/tasks/task_b_68e323ee66c483218481594ae23378d4