### PR TITLE
P1-T3: Create package skeleton

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -10,7 +10,7 @@
 ## Phase 1 – Project Setup & Scaffolding
 - [x] Initialize Python project (PEP 621 `pyproject.toml`, `src/` layout, tests/) (repo builds locally) [#P1-T1]
 - [x] Add console entry point for `{ENTRYPOINT}` in `pyproject.toml` (entry shows in `pip install -e .`) [#P1-T2]
-- [ ] Create package skeleton `src/{PROJECT_SLUG}/cli.py` and `src/{PROJECT_SLUG}/core/__init__.py` (imports succeed) [#P1-T3]
+- [x] Create package skeleton `src/{PROJECT_SLUG}/cli.py` and `src/{PROJECT_SLUG}/core/__init__.py` (imports succeed) [#P1-T3]
 - [ ] Add `.gitignore` for Python, build, and test artifacts (ignored files confirmed) [#P1-T4]
 - [ ] Add `ruff` config and minimal rule-set in `pyproject.toml` (ruff runs clean) [#P1-T5]
 - [ ] Add `pytest` config (`-q`, `pythonpath=src`) (tests discover/run) [#P1-T6]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ description = "Utilities for inspecting and ripping optical discs."
 authors = [{ name = "discripper contributors" }]
 license = { text = "MIT" }
 requires-python = ">=3.10"
+dependencies = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+]
 
 [project.scripts]
 discripper = "discripper.cli:main"

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -1,0 +1,9 @@
+"""Core functionality placeholder package for discripper."""
+
+from __future__ import annotations
+
+__all__ = [
+    "__version__",
+]
+
+__version__ = "0.0.0"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -2,6 +2,7 @@
 
 import discripper
 from discripper import cli
+from discripper import core
 
 
 def test_version_is_string() -> None:
@@ -19,3 +20,10 @@ def test_cli_main_prints_placeholder(capsys) -> None:
 
     assert exit_code == 0
     assert "Usage: discripper" in captured.out
+
+
+def test_core_version_is_exposed() -> None:
+    """The core package exposes a placeholder version string."""
+
+    assert isinstance(core.__version__, str)
+    assert core.__version__ != ""


### PR DESCRIPTION
## Summary
- add a placeholder `discripper.core` package so the namespace can be imported
- include pytest-cov dependency to satisfy the coverage gate
- extend smoke tests to exercise the new core package version stub

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80
- python -c "import discripper; import discripper.cli; import discripper.core"

------
https://chatgpt.com/codex/tasks/task_b_68e3251af9748321bce6cf18e6e20ff2