### PR TITLE
#P1-T5 Configure Ruff linting

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -12,7 +12,7 @@
 - [x] Add console entry point for `{ENTRYPOINT}` in `pyproject.toml` (entry shows in `pip install -e .`) [#P1-T2]
 - [x] Create package skeleton `src/{PROJECT_SLUG}/cli.py` and `src/{PROJECT_SLUG}/core/__init__.py` (imports succeed) [#P1-T3]
 - [x] Add `.gitignore` for Python, build, and test artifacts (ignored files confirmed) [#P1-T4]
-- [ ] Add `ruff` config and minimal rule-set in `pyproject.toml` (ruff runs clean) [#P1-T5]
+- [x] Add `ruff` config and minimal rule-set in `pyproject.toml` (ruff runs clean) [#P1-T5]
 - [ ] Add `pytest` config (`-q`, `pythonpath=src`) (tests discover/run) [#P1-T6]
 - [ ] Add `LICENSE` and minimal top-level `README.md` (files present) [#P1-T7]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,10 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F"]

--- a/src/discripper/cli.py
+++ b/src/discripper/cli.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import sys
 
-_PLACEHOLDER_USAGE = """discripper CLI (placeholder)\n\nUsage: discripper [options]\n\nThis interface will be implemented in future tasks."""
+_PLACEHOLDER_USAGE = (
+    "discripper CLI (placeholder)\n\n"
+    "Usage: discripper [options]\n\n"
+    "This interface will be implemented in future tasks."
+)
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- add a Ruff configuration targeting Python 3.10 with core error/flake checks
- wrap the CLI placeholder usage string so it adheres to the new line-length rule
- mark task #P1-T5 complete in TASKS.md

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Task Reference
- [#P1-T5](TASKS.md#L15)

------
https://chatgpt.com/codex/tasks/task_b_68e327b138488321b2d73035cb3e0941