### PR TITLE
#P1-T6 Configure pytest defaults

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -13,7 +13,7 @@
 - [x] Create package skeleton `src/{PROJECT_SLUG}/cli.py` and `src/{PROJECT_SLUG}/core/__init__.py` (imports succeed) [#P1-T3]
 - [x] Add `.gitignore` for Python, build, and test artifacts (ignored files confirmed) [#P1-T4]
 - [x] Add `ruff` config and minimal rule-set in `pyproject.toml` (ruff runs clean) [#P1-T5]
-- [ ] Add `pytest` config (`-q`, `pythonpath=src`) (tests discover/run) [#P1-T6]
+- [x] Add `pytest` config (`-q`, `pythonpath=src`) (tests discover/run) [#P1-T6]
 - [ ] Add `LICENSE` and minimal top-level `README.md` (files present) [#P1-T7]
 
 ## Phase 2 – Config & CLI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,7 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+pythonpath = ["src"]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,5 +1,8 @@
 """Smoke tests for the discripper package."""
 
+from pathlib import Path
+import sys
+
 import discripper
 from discripper import cli
 from discripper import core
@@ -27,3 +30,13 @@ def test_core_version_is_exposed() -> None:
 
     assert isinstance(core.__version__, str)
     assert core.__version__ != ""
+
+
+def test_pytest_pythonpath_includes_src() -> None:
+    """Pytest configuration ensures the source directory is importable."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    expected_src = repo_root / "src"
+
+    assert expected_src.exists()
+    assert any(Path(path).resolve() == expected_src for path in map(Path, sys.path))


### PR DESCRIPTION
## Summary
- add a pytest configuration block in `pyproject.toml` to run quietly and expose the `src` directory
- extend the smoke tests to verify the configured python path includes the `src` tree
- mark TASKS.md item #P1-T6 complete after updating configuration and tests

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Task
- TASKS.md line 16

------
https://chatgpt.com/codex/tasks/task_b_68e32844f75c832185f89db7374b4788