### PR TITLE
Add license and README [#P1-T7]

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 discripper contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# discripper
+
+`discripper` is a command-line utility for inspecting optical discs and planning ripping workflows. The tool will detect whether a disc contains a movie or a TV series, recommend output naming, and coordinate ripping tools so collections stay organized.
+
+## Status
+
+This repository is under active development. Core functionality such as configuration loading, device inspection, and ripping orchestration is tracked in `PRD.md` and `TASKS.md`.
+
+## Getting Started
+
+```bash
+pip install -e .
+```
+
+Once the CLI is implemented you will be able to run:
+
+```bash
+discripper --help
+```
+
+Configuration will default to `~/.config/discripper.yaml` with CLI flags to override key settings. See `PRD.md` for the planned feature roadmap.
+
+## Contributing
+
+1. Check the next open item in `TASKS.md`.
+2. Implement the change with tests.
+3. Run the local verification gates documented in `.codex/instructions/LOCAL_GATES.md`.
+4. Open a pull request linking the task ID.
+
+## License
+
+This project is licensed under the terms of the [MIT License](LICENSE).

--- a/TASKS.md
+++ b/TASKS.md
@@ -14,7 +14,7 @@
 - [x] Add `.gitignore` for Python, build, and test artifacts (ignored files confirmed) [#P1-T4]
 - [x] Add `ruff` config and minimal rule-set in `pyproject.toml` (ruff runs clean) [#P1-T5]
 - [x] Add `pytest` config (`-q`, `pythonpath=src`) (tests discover/run) [#P1-T6]
-- [ ] Add `LICENSE` and minimal top-level `README.md` (files present) [#P1-T7]
+- [x] Add `LICENSE` and minimal top-level `README.md` (files present) [#P1-T7]
 
 ## Phase 2 – Config & CLI
 - [ ] Implement config loader reading `{CONFIG_PATH}` (defaults used if file missing) [#P2-T1]


### PR DESCRIPTION
## Summary
- add an MIT LICENSE file for the project
- document the project status and contribution flow in a new README
- mark roadmap task #P1-T7 as complete after adding the docs

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e328d2cc2883218ae0c5534d9f7856