### PR TITLE
Implement config loader [#P2-T1]

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -17,7 +17,7 @@
 - [x] Add `LICENSE` and minimal top-level `README.md` (files present) [#P1-T7]
 
 ## Phase 2 – Config & CLI
-- [ ] Implement config loader reading `{CONFIG_PATH}` (defaults used if file missing) [#P2-T1]
+- [x] Implement config loader reading `{CONFIG_PATH}` (defaults used if file missing) [#P2-T1]
 - [ ] Implement CLI flags: `--config`, `--verbose`, `--dry-run` (flags override config values) [#P2-T2]
 - [ ] Add device argument with default `/dev/sr0` (help shows default) [#P2-T3]
 - [ ] Wire logging levels (INFO default, DEBUG with `--verbose`) (log level toggles) [#P2-T4]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "PyYAML>=6.0",
 ]
 
 [project.scripts]

--- a/src/discripper/config.py
+++ b/src/discripper/config.py
@@ -1,0 +1,74 @@
+"""Configuration loading utilities for discripper."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+CONFIG_PATH = Path("~/.config/discripper.yaml")
+DEFAULT_CONFIG: dict[str, Any] = {
+    "output_directory": str(Path.home() / "Videos"),
+    "compression": False,
+    "naming": {
+        "separator": "_",
+        "lowercase": False,
+    },
+    "logging": {
+        "level": "INFO",
+    },
+}
+
+__all__ = ["CONFIG_PATH", "DEFAULT_CONFIG", "load_config"]
+
+
+def _merge_config(base: Mapping[str, Any], overrides: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a deep-merged copy of *base* with values from *overrides*."""
+
+    merged: dict[str, Any] = deepcopy(dict(base))
+    for key, value in overrides.items():
+        if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+            merged[key] = _merge_config(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_config(path: str | Path | None = None) -> dict[str, Any]:
+    """Load the discripper configuration.
+
+    Parameters
+    ----------
+    path:
+        Optional path to the configuration file. When omitted, :data:`CONFIG_PATH` is used.
+
+    Returns
+    -------
+    dict[str, Any]
+        The configuration dictionary with defaults applied.
+
+    Raises
+    ------
+    ValueError
+        If the configuration file exists but does not contain a mapping.
+    """
+
+    config_path = Path(path).expanduser() if path else CONFIG_PATH.expanduser()
+
+    if not config_path.exists():
+        return deepcopy(DEFAULT_CONFIG)
+
+    raw_content = config_path.read_text(encoding="utf-8")
+    if not raw_content.strip():
+        return deepcopy(DEFAULT_CONFIG)
+
+    loaded = yaml.safe_load(raw_content)
+    if loaded is None:
+        return deepcopy(DEFAULT_CONFIG)
+
+    if not isinstance(loaded, Mapping):
+        raise ValueError("Configuration file must define a mapping")
+
+    return _merge_config(DEFAULT_CONFIG, loaded)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from discripper import config
+
+
+def test_load_config_returns_defaults_when_file_missing(tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing.yaml"
+
+    loaded = config.load_config(missing_path)
+
+    assert loaded == config.DEFAULT_CONFIG
+
+
+def test_load_config_overrides_defaults(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "output_directory: /mnt/media\n" "naming:\n" "  lowercase: true\n"
+    )
+
+    loaded = config.load_config(config_file)
+
+    assert loaded["output_directory"] == "/mnt/media"
+    assert loaded["naming"]["lowercase"] is True
+    assert loaded["naming"]["separator"] == config.DEFAULT_CONFIG["naming"]["separator"]
+
+
+def test_load_config_rejects_non_mapping(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("[]")
+
+    with pytest.raises(ValueError):
+        config.load_config(config_file)


### PR DESCRIPTION
## Summary
- add a configuration module that loads ~/.config/discripper.yaml with safe defaults and deep merge semantics
- cover config loading behavior with unit tests for defaults, overrides, and invalid content
- declare the PyYAML dependency required for YAML parsing

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e3294f16408321a6d74d0302fb953f