### PR TITLE
#P2-T2 Implement CLI flag overrides

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -18,7 +18,7 @@
 
 ## Phase 2 – Config & CLI
 - [x] Implement config loader reading `{CONFIG_PATH}` (defaults used if file missing) [#P2-T1]
-- [ ] Implement CLI flags: `--config`, `--verbose`, `--dry-run` (flags override config values) [#P2-T2]
+- [x] Implement CLI flags: `--config`, `--verbose`, `--dry-run` (flags override config values) [#P2-T2]
 - [ ] Add device argument with default `/dev/sr0` (help shows default) [#P2-T3]
 - [ ] Wire logging levels (INFO default, DEBUG with `--verbose`) (log level toggles) [#P2-T4]
 - [ ] Add schema fields: `output_directory`, `compression`, `naming.separator`, `naming.lowercase`, `logging.level` (schema validated) [#P2-T5]

--- a/src/discripper/cli.py
+++ b/src/discripper/cli.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import argparse
 import sys
+from typing import Any, Sequence
+
+from .config import load_config
 
 _PLACEHOLDER_USAGE = (
     "discripper CLI (placeholder)\n\n"
@@ -11,8 +15,54 @@ _PLACEHOLDER_USAGE = (
 )
 
 
-def main() -> int:
+def build_argument_parser() -> argparse.ArgumentParser:
+    """Create and return the argument parser for the CLI."""
+
+    parser = argparse.ArgumentParser(description="discripper command-line interface")
+    parser.add_argument(
+        "--config",
+        dest="config_path",
+        help="Path to the configuration file to use.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose (DEBUG) logging output.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Perform a dry run without executing side effects.",
+    )
+    return parser
+
+
+def parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments from *argv* or :data:`sys.argv`."""
+
+    parser = build_argument_parser()
+    return parser.parse_args(argv)
+
+
+def resolve_cli_config(args: argparse.Namespace) -> dict[str, Any]:
+    """Return the effective configuration after applying CLI overrides."""
+
+    config = load_config(args.config_path)
+
+    if args.verbose:
+        config.setdefault("logging", {})["level"] = "DEBUG"
+
+    if args.dry_run:
+        config["dry_run"] = True
+
+    return config
+
+
+def main(argv: Sequence[str] | None = None) -> int:
     """Entry point for the console script."""
+
+    args = parse_arguments(argv)
+    resolve_cli_config(args)
 
     print(_PLACEHOLDER_USAGE)
     return 0

--- a/src/discripper/config.py
+++ b/src/discripper/config.py
@@ -12,6 +12,7 @@ CONFIG_PATH = Path("~/.config/discripper.yaml")
 DEFAULT_CONFIG: dict[str, Any] = {
     "output_directory": str(Path.home() / "Videos"),
     "compression": False,
+    "dry_run": False,
     "naming": {
         "separator": "_",
         "lowercase": False,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,65 @@
+"""Tests for the discripper command-line interface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from discripper import cli
+
+
+def _write_config(tmp_path: Path, content: dict[str, object]) -> Path:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(content), encoding="utf-8")
+    return config_path
+
+
+def test_parse_arguments_supports_expected_flags() -> None:
+    """The CLI parser recognises the config, verbose, and dry-run flags."""
+
+    args = cli.parse_arguments(["--config", "example.yaml", "--verbose", "--dry-run"])
+
+    assert args.config_path == "example.yaml"
+    assert args.verbose is True
+    assert args.dry_run is True
+
+
+def test_resolve_cli_config_uses_custom_config_path(tmp_path) -> None:
+    """Providing --config loads and returns the specified configuration file."""
+
+    config_path = _write_config(
+        tmp_path,
+        {
+            "logging": {"level": "WARNING"},
+            "dry_run": False,
+        },
+    )
+
+    args = cli.parse_arguments(["--config", str(config_path)])
+    resolved = cli.resolve_cli_config(args)
+
+    assert resolved["logging"]["level"] == "WARNING"
+    assert resolved["dry_run"] is False
+
+
+def test_resolve_cli_config_overrides_logging_with_verbose(tmp_path) -> None:
+    """--verbose forces the logging level to DEBUG regardless of config value."""
+
+    config_path = _write_config(tmp_path, {"logging": {"level": "INFO"}})
+
+    args = cli.parse_arguments(["--config", str(config_path), "--verbose"])
+    resolved = cli.resolve_cli_config(args)
+
+    assert resolved["logging"]["level"] == "DEBUG"
+
+
+def test_resolve_cli_config_sets_dry_run_flag(tmp_path) -> None:
+    """--dry-run updates the configuration to reflect a dry run."""
+
+    config_path = _write_config(tmp_path, {"dry_run": False})
+
+    args = cli.parse_arguments(["--config", str(config_path), "--dry-run"])
+    resolved = cli.resolve_cli_config(args)
+
+    assert resolved["dry_run"] is True

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -18,7 +18,7 @@ def test_version_is_string() -> None:
 def test_cli_main_prints_placeholder(capsys) -> None:
     """The CLI main function prints the placeholder usage text."""
 
-    exit_code = cli.main()
+    exit_code = cli.main([])
     captured = capsys.readouterr()
 
     assert exit_code == 0


### PR DESCRIPTION
## Summary
- introduce an argparse-based CLI parser with --config, --verbose, and --dry-run flags
- load configuration via the requested path and apply CLI overrides (verbose, dry-run)
- cover the new behavior with focused CLI tests and adjust the existing placeholder smoke test

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Risks & Rollback
- Low risk: changes are limited to CLI parsing and configuration helpers. Roll back by reverting this PR if regressions appear.

## Links
- TASKS.md#L21


------
https://chatgpt.com/codex/tasks/task_b_68e32b06a35c8321839a254c72db05e0