### PR TITLE
Add default device argument to CLI (#P2-T3)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -19,7 +19,7 @@
 ## Phase 2 – Config & CLI
 - [x] Implement config loader reading `{CONFIG_PATH}` (defaults used if file missing) [#P2-T1]
 - [x] Implement CLI flags: `--config`, `--verbose`, `--dry-run` (flags override config values) [#P2-T2]
-- [ ] Add device argument with default `/dev/sr0` (help shows default) [#P2-T3]
+- [x] Add device argument with default `/dev/sr0` (help shows default) [#P2-T3]
 - [ ] Wire logging levels (INFO default, DEBUG with `--verbose`) (log level toggles) [#P2-T4]
 - [ ] Add schema fields: `output_directory`, `compression`, `naming.separator`, `naming.lowercase`, `logging.level` (schema validated) [#P2-T5]
 - [ ] Unit tests for config precedence (defaults < config file < CLI flags) (pytest passes) [#P2-T6]

--- a/src/discripper/cli.py
+++ b/src/discripper/cli.py
@@ -20,6 +20,12 @@ def build_argument_parser() -> argparse.ArgumentParser:
 
     parser = argparse.ArgumentParser(description="discripper command-line interface")
     parser.add_argument(
+        "device",
+        nargs="?",
+        default="/dev/sr0",
+        help="Path to the optical media device (default: %(default)s).",
+    )
+    parser.add_argument(
         "--config",
         dest="config_path",
         help="Path to the configuration file to use.",
@@ -48,6 +54,8 @@ def resolve_cli_config(args: argparse.Namespace) -> dict[str, Any]:
     """Return the effective configuration after applying CLI overrides."""
 
     config = load_config(args.config_path)
+
+    config["device"] = args.device
 
     if args.verbose:
         config.setdefault("logging", {})["level"] = "DEBUG"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,14 @@ def test_parse_arguments_supports_expected_flags() -> None:
     assert args.dry_run is True
 
 
+def test_parse_arguments_includes_device_with_default() -> None:
+    """The parser exposes a device argument with the expected default value."""
+
+    args = cli.parse_arguments([])
+
+    assert args.device == "/dev/sr0"
+
+
 def test_resolve_cli_config_uses_custom_config_path(tmp_path) -> None:
     """Providing --config loads and returns the specified configuration file."""
 
@@ -41,6 +49,17 @@ def test_resolve_cli_config_uses_custom_config_path(tmp_path) -> None:
 
     assert resolved["logging"]["level"] == "WARNING"
     assert resolved["dry_run"] is False
+
+
+def test_resolve_cli_config_sets_device_from_arguments(tmp_path) -> None:
+    """The device argument is propagated into the resolved configuration."""
+
+    config_path = _write_config(tmp_path, {})
+
+    args = cli.parse_arguments(["--config", str(config_path), "/dev/dvd"])
+    resolved = cli.resolve_cli_config(args)
+
+    assert resolved["device"] == "/dev/dvd"
 
 
 def test_resolve_cli_config_overrides_logging_with_verbose(tmp_path) -> None:
@@ -63,3 +82,11 @@ def test_resolve_cli_config_sets_dry_run_flag(tmp_path) -> None:
     resolved = cli.resolve_cli_config(args)
 
     assert resolved["dry_run"] is True
+
+
+def test_cli_help_mentions_device_default() -> None:
+    """The help output mentions the default device path."""
+
+    help_text = cli.build_argument_parser().format_help()
+
+    assert "/dev/sr0" in help_text


### PR DESCRIPTION
## Summary
- add a positional device argument with a default of /dev/sr0 to the CLI parser
- propagate the resolved device into the runtime configuration
- expand CLI tests to cover device defaults and help output

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e32c46974083218bbf09bfa4535e53