### PR TITLE
[#P2-T5] Add config schema validation

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -21,7 +21,7 @@
 - [x] Implement CLI flags: `--config`, `--verbose`, `--dry-run` (flags override config values) [#P2-T2]
 - [x] Add device argument with default `/dev/sr0` (help shows default) [#P2-T3]
 - [x] Wire logging levels (INFO default, DEBUG with `--verbose`) (log level toggles) [#P2-T4]
-- [ ] Add schema fields: `output_directory`, `compression`, `naming.separator`, `naming.lowercase`, `logging.level` (schema validated) [#P2-T5]
+- [x] Add schema fields: `output_directory`, `compression`, `naming.separator`, `naming.lowercase`, `logging.level` (schema validated) [#P2-T5]
 - [ ] Unit tests for config precedence (defaults < config file < CLI flags) (pytest passes) [#P2-T6]
 - [ ] `{ENTRYPOINT} --help` shows usage and options (help includes flags/args) [#P2-T7]
 

--- a/src/discripper/config.py
+++ b/src/discripper/config.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 import yaml
 
@@ -22,7 +23,20 @@ DEFAULT_CONFIG: dict[str, Any] = {
     },
 }
 
-__all__ = ["CONFIG_PATH", "DEFAULT_CONFIG", "load_config"]
+CONFIG_SCHEMA: dict[str, Any] = {
+    "output_directory": str,
+    "compression": bool,
+    "dry_run": bool,
+    "naming": {
+        "separator": str,
+        "lowercase": bool,
+    },
+    "logging": {
+        "level": (str, int),
+    },
+}
+
+__all__ = ["CONFIG_PATH", "DEFAULT_CONFIG", "CONFIG_SCHEMA", "load_config"]
 
 
 def _merge_config(base: Mapping[str, Any], overrides: Mapping[str, Any]) -> dict[str, Any]:
@@ -35,6 +49,55 @@ def _merge_config(base: Mapping[str, Any], overrides: Mapping[str, Any]) -> dict
         else:
             merged[key] = value
     return merged
+
+
+def _ensure_type(value: Any, expected: Any, path: str) -> None:
+    if isinstance(expected, tuple):
+        if not isinstance(value, expected):
+            expected_names = ", ".join(sorted({t.__name__ for t in expected}))
+            raise ValueError(
+                f"Configuration field '{path}' must be one of the types: {expected_names}"
+            )
+        return
+
+    if expected is bool:
+        if not isinstance(value, bool):
+            raise ValueError(f"Configuration field '{path}' must be a boolean")
+        return
+
+    if expected is str:
+        if not isinstance(value, str):
+            raise ValueError(f"Configuration field '{path}' must be a string")
+        return
+
+    if isinstance(expected, Mapping):
+        if not isinstance(value, Mapping):
+            raise ValueError(f"Configuration field '{path}' must be a mapping")
+        _validate_against_schema(value, expected, prefix=path)
+        return
+
+    raise TypeError(f"Unsupported schema type for '{path}': {expected!r}")
+
+
+def _validate_against_schema(
+    config: Mapping[str, Any], schema: Mapping[str, Any], *, prefix: str = ""
+) -> None:
+    for key, expected in schema.items():
+        field_path = f"{prefix}.{key}" if prefix else key
+        if key not in config:
+            raise ValueError(f"Configuration field '{field_path}' is required")
+        value = config[key]
+        _ensure_type(value, expected, field_path)
+
+
+def _validate_config(config: Mapping[str, Any]) -> None:
+    _validate_against_schema(config, CONFIG_SCHEMA)
+
+
+def _validated_defaults() -> dict[str, Any]:
+    defaults = deepcopy(DEFAULT_CONFIG)
+    _validate_config(defaults)
+    return defaults
 
 
 def load_config(path: str | Path | None = None) -> dict[str, Any]:
@@ -59,17 +122,19 @@ def load_config(path: str | Path | None = None) -> dict[str, Any]:
     config_path = Path(path).expanduser() if path else CONFIG_PATH.expanduser()
 
     if not config_path.exists():
-        return deepcopy(DEFAULT_CONFIG)
+        return _validated_defaults()
 
     raw_content = config_path.read_text(encoding="utf-8")
     if not raw_content.strip():
-        return deepcopy(DEFAULT_CONFIG)
+        return _validated_defaults()
 
     loaded = yaml.safe_load(raw_content)
     if loaded is None:
-        return deepcopy(DEFAULT_CONFIG)
+        return _validated_defaults()
 
     if not isinstance(loaded, Mapping):
         raise ValueError("Configuration file must define a mapping")
 
-    return _merge_config(DEFAULT_CONFIG, loaded)
+    merged = _merge_config(DEFAULT_CONFIG, loaded)
+    _validate_config(merged)
+    return merged

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,3 +34,19 @@ def test_load_config_rejects_non_mapping(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError):
         config.load_config(config_file)
+
+
+def test_load_config_validates_schema_types(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("compression: 1\n")
+
+    with pytest.raises(ValueError, match="compression"):
+        config.load_config(config_file)
+
+
+def test_load_config_validates_nested_schema(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("naming: lowercase\n")
+
+    with pytest.raises(ValueError, match="naming"):
+        config.load_config(config_file)


### PR DESCRIPTION
## Summary
- add a CONFIG_SCHEMA definition and validate configuration mappings against it
- ensure default configuration values are validated and merged configs raise clear errors when invalid
- add unit tests covering invalid schema overrides and mark TASKS.md entry #P2-T5 complete

Task: TASKS.md (#P2-T5)

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Risks
- Low: stricter config validation could reject previously accepted but incorrect values.

## Rollback
- Revert this commit.


------
https://chatgpt.com/codex/tasks/task_b_68e32e291de083218ef74ae110ccf8bb