### PR TITLE
#P2-T6 Add config precedence test

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -22,7 +22,7 @@
 - [x] Add device argument with default `/dev/sr0` (help shows default) [#P2-T3]
 - [x] Wire logging levels (INFO default, DEBUG with `--verbose`) (log level toggles) [#P2-T4]
 - [x] Add schema fields: `output_directory`, `compression`, `naming.separator`, `naming.lowercase`, `logging.level` (schema validated) [#P2-T5]
-- [ ] Unit tests for config precedence (defaults < config file < CLI flags) (pytest passes) [#P2-T6]
+- [x] Unit tests for config precedence (defaults < config file < CLI flags) (pytest passes) [#P2-T6]
 - [ ] `{ENTRYPOINT} --help` shows usage and options (help includes flags/args) [#P2-T7]
 
 ## Phase 3 – Core Inspection / Input Acquisition

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,6 +85,28 @@ def test_resolve_cli_config_sets_dry_run_flag(tmp_path) -> None:
     assert resolved["dry_run"] is True
 
 
+def test_resolve_cli_config_applies_precedence(tmp_path) -> None:
+    """Defaults are overridden by config file, which in turn yields to CLI flags."""
+
+    config_path = _write_config(
+        tmp_path,
+        {
+            "output_directory": "/mnt/custom",
+            "logging": {"level": "WARNING"},
+            "dry_run": False,
+        },
+    )
+
+    args = cli.parse_arguments(
+        ["--config", str(config_path), "--verbose", "--dry-run"]
+    )
+    resolved = cli.resolve_cli_config(args)
+
+    assert resolved["output_directory"] == "/mnt/custom"
+    assert resolved["logging"]["level"] == "DEBUG"
+    assert resolved["dry_run"] is True
+
+
 def test_cli_help_mentions_device_default() -> None:
     """The help output mentions the default device path."""
 


### PR DESCRIPTION
## Summary
- add a CLI unit test that exercises default, config file, and CLI flag precedence
- mark the Phase 2 precedence testing task as complete in TASKS.md

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Risks & Rollback
- Low risk: changes are limited to tests and task tracking.
- Rollback by reverting this commit.

## Task Reference
- [TASKS.md#L25](TASKS.md#L25)


------
https://chatgpt.com/codex/tasks/task_b_68e32f4023008321af1046b8649465ca