### PR TITLE
Complete #P2-T7: ensure CLI help shows options

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -23,7 +23,7 @@
 - [x] Wire logging levels (INFO default, DEBUG with `--verbose`) (log level toggles) [#P2-T4]
 - [x] Add schema fields: `output_directory`, `compression`, `naming.separator`, `naming.lowercase`, `logging.level` (schema validated) [#P2-T5]
 - [x] Unit tests for config precedence (defaults < config file < CLI flags) (pytest passes) [#P2-T6]
-- [ ] `{ENTRYPOINT} --help` shows usage and options (help includes flags/args) [#P2-T7]
+- [x] `{ENTRYPOINT} --help` shows usage and options (help includes flags/args) [#P2-T7]
 
 ## Phase 3 – Core Inspection / Input Acquisition
 - [ ] Define dataclasses `DiscInfo`, `TitleInfo` (fields for label, titles, chapters, durations) [#P3-T1]

--- a/src/discripper/cli.py
+++ b/src/discripper/cli.py
@@ -19,7 +19,9 @@ _PLACEHOLDER_USAGE = (
 def build_argument_parser() -> argparse.ArgumentParser:
     """Create and return the argument parser for the CLI."""
 
-    parser = argparse.ArgumentParser(description="discripper command-line interface")
+    parser = argparse.ArgumentParser(
+        prog="discripper", description="discripper command-line interface"
+    )
     parser.add_argument(
         "device",
         nargs="?",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import yaml
 
 from discripper import cli
+import pytest
 
 
 def _write_config(tmp_path: Path, content: dict[str, object]) -> Path:
@@ -113,6 +114,22 @@ def test_cli_help_mentions_device_default() -> None:
     help_text = cli.build_argument_parser().format_help()
 
     assert "/dev/sr0" in help_text
+
+
+def test_cli_main_help_output_lists_expected_options(capsys) -> None:
+    """Running the CLI with --help shows usage and all defined options."""
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["--help"])
+
+    assert exc_info.value.code == 0
+
+    captured = capsys.readouterr().out
+
+    assert "usage: discripper" in captured
+    assert "--config" in captured
+    assert "--verbose" in captured
+    assert "--dry-run" in captured
 
 
 def test_main_configures_info_logging_by_default() -> None:


### PR DESCRIPTION
## Summary
- set the CLI parser program name to `discripper` so the help text mirrors the entry point
- add a regression test asserting `discripper --help` lists the expected options
- mark roadmap task #P2-T7 as complete

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_68e331ffa44c83219cc34a0680b5b92c