### PR TITLE
[#P3-T1] Define disc metadata dataclasses

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -26,7 +26,7 @@
 - [x] `{ENTRYPOINT} --help` shows usage and options (help includes flags/args) [#P2-T7]
 
 ## Phase 3 – Core Inspection / Input Acquisition
-- [ ] Define dataclasses `DiscInfo`, `TitleInfo` (fields for label, titles, chapters, durations) [#P3-T1]
+- [x] Define dataclasses `DiscInfo`, `TitleInfo` (fields for label, titles, chapters, durations) [#P3-T1]
 - [ ] Implement tool discovery for `lsdvd`, `ffprobe`, and Blu-ray inspector (detect availability) [#P3-T2]
 - [ ] Implement DVD inspector adapter using `lsdvd` where available (parses durations/titles) [#P3-T3]
 - [ ] Implement fallback inspector using `ffprobe` on device (best-effort title/duration extraction) [#P3-T4]

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -1,9 +1,39 @@
-"""Core functionality placeholder package for discripper."""
+"""Core data structures and functionality for :mod:`discripper`."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Tuple
+
 __all__ = [
+    "DiscInfo",
+    "TitleInfo",
     "__version__",
 ]
+
+
+@dataclass(frozen=True, slots=True)
+class TitleInfo:
+    """Metadata describing a single title discovered on a disc."""
+
+    label: str
+    duration: timedelta
+    chapters: Tuple[timedelta, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple conversion
+        object.__setattr__(self, "chapters", tuple(self.chapters))
+
+
+@dataclass(frozen=True, slots=True)
+class DiscInfo:
+    """Aggregate information for a physical disc and its titles."""
+
+    label: str
+    titles: Tuple[TitleInfo, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple conversion
+        object.__setattr__(self, "titles", tuple(self.titles))
+
 
 __version__ = "0.0.0"

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import timedelta
+
+import pytest
+
+from discripper.core import DiscInfo, TitleInfo
+
+
+def test_title_info_is_frozen_and_normalizes_chapters() -> None:
+    chapters = [timedelta(minutes=5), timedelta(minutes=10)]
+    info = TitleInfo(label="Title 1", duration=timedelta(minutes=42), chapters=chapters)
+
+    assert info.label == "Title 1"
+    assert info.duration == timedelta(minutes=42)
+    assert info.chapters == (timedelta(minutes=5), timedelta(minutes=10))
+
+    with pytest.raises(FrozenInstanceError):
+        info.label = "Another"
+
+
+def test_disc_info_collects_titles() -> None:
+    title = TitleInfo(
+        label="Pilot",
+        duration=timedelta(minutes=45),
+        chapters=(timedelta(minutes=20), timedelta(minutes=25)),
+    )
+    disc = DiscInfo(label="Series Disc", titles=[title])
+
+    assert disc.label == "Series Disc"
+    assert disc.titles == (title,)
+
+    with pytest.raises(FrozenInstanceError):
+        disc.titles = ()


### PR DESCRIPTION
## Summary
- add immutable `TitleInfo` and `DiscInfo` dataclasses that normalize chapter and title collections
- expose the new dataclasses from `discripper.core`
- cover the dataclasses with unit tests and mark roadmap task #P3-T1 complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e332c9cd50832188d60e28321b7d46