### PR TITLE
Implement inspector tool discovery [#P3-T2]

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -27,7 +27,7 @@
 
 ## Phase 3 – Core Inspection / Input Acquisition
 - [x] Define dataclasses `DiscInfo`, `TitleInfo` (fields for label, titles, chapters, durations) [#P3-T1]
-- [ ] Implement tool discovery for `lsdvd`, `ffprobe`, and Blu-ray inspector (detect availability) [#P3-T2]
+- [x] Implement tool discovery for `lsdvd`, `ffprobe`, and Blu-ray inspector (detect availability) [#P3-T2]
 - [ ] Implement DVD inspector adapter using `lsdvd` where available (parses durations/titles) [#P3-T3]
 - [ ] Implement fallback inspector using `ffprobe` on device (best-effort title/duration extraction) [#P3-T4]
 - [ ] Stub Blu-ray path (documented detection; usable later) (graceful “not supported yet” message) [#P3-T5]

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -6,9 +6,20 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Tuple
 
+from .discovery import (
+    BLURAY_INSPECTOR_CANDIDATES,
+    InspectionTools,
+    ToolAvailability,
+    discover_inspection_tools,
+)
+
 __all__ = [
     "DiscInfo",
     "TitleInfo",
+    "InspectionTools",
+    "ToolAvailability",
+    "discover_inspection_tools",
+    "BLURAY_INSPECTOR_CANDIDATES",
     "__version__",
 ]
 

--- a/src/discripper/core/discovery.py
+++ b/src/discripper/core/discovery.py
@@ -1,0 +1,68 @@
+"""Discovery helpers for external inspection tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from shutil import which as default_which
+from typing import Callable, Iterable, Optional
+
+__all__ = [
+    "ToolAvailability",
+    "InspectionTools",
+    "BLURAY_INSPECTOR_CANDIDATES",
+    "discover_inspection_tools",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ToolAvailability:
+    """Information about a discovered external command."""
+
+    command: str
+    path: str
+
+
+@dataclass(frozen=True, slots=True)
+class InspectionTools:
+    """Bundle of the external tools used for disc inspection."""
+
+    dvd: Optional[ToolAvailability]
+    fallback: Optional[ToolAvailability]
+    blu_ray: Optional[ToolAvailability]
+
+
+BLURAY_INSPECTOR_CANDIDATES: tuple[str, ...] = (
+    "makemkvcon",
+    "bd_info",
+)
+"""Candidate commands that can act as a Blu-ray inspector."""
+
+
+def _discover_single(
+    command: str, which: Callable[[str], Optional[str]],
+) -> Optional[ToolAvailability]:
+    path = which(command)
+    if path:
+        return ToolAvailability(command=command, path=path)
+    return None
+
+
+def _discover_first(
+    commands: Iterable[str], which: Callable[[str], Optional[str]],
+) -> Optional[ToolAvailability]:
+    for command in commands:
+        found = _discover_single(command, which)
+        if found is not None:
+            return found
+    return None
+
+
+def discover_inspection_tools(
+    *, which: Callable[[str], Optional[str]] = default_which,
+) -> InspectionTools:
+    """Return available inspection tools for DVD and Blu-ray discs."""
+
+    dvd = _discover_single("lsdvd", which)
+    fallback = _discover_single("ffprobe", which)
+    blu_ray = _discover_first(BLURAY_INSPECTOR_CANDIDATES, which)
+    return InspectionTools(dvd=dvd, fallback=fallback, blu_ray=blu_ray)

--- a/tests/test_tool_discovery.py
+++ b/tests/test_tool_discovery.py
@@ -1,0 +1,63 @@
+"""Tests for external tool discovery helpers."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from discripper.core import (
+    BLURAY_INSPECTOR_CANDIDATES,
+    InspectionTools,
+    ToolAvailability,
+    discover_inspection_tools,
+)
+
+
+def test_discover_inspection_tools_prefers_primary_candidates() -> None:
+    paths = {
+        "lsdvd": "/usr/bin/lsdvd",
+        "ffprobe": "/usr/bin/ffprobe",
+        "makemkvcon": "/opt/makemkv/bin/makemkvcon",
+        "bd_info": "/usr/local/bin/bd_info",
+    }
+
+    def fake_which(command: str) -> Optional[str]:
+        return paths.get(command)
+
+    discovered = discover_inspection_tools(which=fake_which)
+
+    assert discovered == InspectionTools(
+        dvd=ToolAvailability("lsdvd", paths["lsdvd"]),
+        fallback=ToolAvailability("ffprobe", paths["ffprobe"]),
+        blu_ray=ToolAvailability("makemkvcon", paths["makemkvcon"]),
+    )
+
+
+def test_discover_inspection_tools_uses_first_available_blu_ray_candidate() -> None:
+    fallback_paths = {
+        "lsdvd": None,
+        "ffprobe": None,
+        "makemkvcon": None,
+        "bd_info": "/usr/bin/bd_info",
+    }
+
+    def fake_which(command: str) -> Optional[str]:
+        return fallback_paths.get(command)
+
+    discovered = discover_inspection_tools(which=fake_which)
+
+    assert discovered.dvd is None
+    assert discovered.fallback is None
+    assert discovered.blu_ray == ToolAvailability("bd_info", "/usr/bin/bd_info")
+
+
+def test_discover_inspection_tools_handles_missing_commands() -> None:
+    def fake_which(command: str) -> Optional[str]:  # pragma: no cover - defensive
+        return None
+
+    discovered = discover_inspection_tools(which=fake_which)
+
+    assert discovered == InspectionTools(dvd=None, fallback=None, blu_ray=None)
+
+
+def test_blu_ray_candidate_list_is_not_empty() -> None:
+    assert BLURAY_INSPECTOR_CANDIDATES


### PR DESCRIPTION
## Summary
- add discovery helpers to locate `lsdvd`, `ffprobe`, and Blu-ray inspector commands
- expose discovery helpers through `discripper.core` for future adapters
- cover discovery behaviour with targeted unit tests

## Testing
- `pip install -e .`
  ```
  Successfully built discripper
  Successfully installed PyYAML-6.0.3 discripper-0.1.0
  ```
- `ruff check .`
  ```
  All checks passed!
  ```
- `pytest -q --cov=src --cov-fail-under=80`
  ```
  ..........................
  TOTAL                                160      9    94%
  ```


------
https://chatgpt.com/codex/tasks/task_b_68e3345d1ca48321b41b358c718ea261