### PR TITLE
[#P3-T3] Implement lsdvd inspector adapter

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -28,7 +28,7 @@
 ## Phase 3 – Core Inspection / Input Acquisition
 - [x] Define dataclasses `DiscInfo`, `TitleInfo` (fields for label, titles, chapters, durations) [#P3-T1]
 - [x] Implement tool discovery for `lsdvd`, `ffprobe`, and Blu-ray inspector (detect availability) [#P3-T2]
-- [ ] Implement DVD inspector adapter using `lsdvd` where available (parses durations/titles) [#P3-T3]
+- [x] Implement DVD inspector adapter using `lsdvd` where available (parses durations/titles) [#P3-T3]
 - [ ] Implement fallback inspector using `ffprobe` on device (best-effort title/duration extraction) [#P3-T4]
 - [ ] Stub Blu-ray path (documented detection; usable later) (graceful “not supported yet” message) [#P3-T5]
 - [ ] Add fake inspector loading JSON fixtures from `tests/fixtures/` (injectable for tests) [#P3-T6]

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -12,6 +12,7 @@ from .discovery import (
     ToolAvailability,
     discover_inspection_tools,
 )
+from .dvd import inspect_dvd
 
 __all__ = [
     "DiscInfo",
@@ -20,6 +21,7 @@ __all__ = [
     "ToolAvailability",
     "discover_inspection_tools",
     "BLURAY_INSPECTOR_CANDIDATES",
+    "inspect_dvd",
     "__version__",
 ]
 

--- a/src/discripper/core/dvd.py
+++ b/src/discripper/core/dvd.py
@@ -1,0 +1,111 @@
+"""DVD inspection using :command:`lsdvd`."""
+
+from __future__ import annotations
+
+import ast
+import re
+from datetime import timedelta
+from subprocess import PIPE, CompletedProcess, run as subprocess_run
+from typing import TYPE_CHECKING, Callable, Iterable, Mapping, Sequence
+
+from .discovery import ToolAvailability
+
+__all__ = ["inspect_dvd"]
+
+Runner = Callable[..., CompletedProcess[str]]
+_DISC_PATTERN = re.compile(r"disc\s*=\s*(\{.*\})", re.DOTALL)
+
+if TYPE_CHECKING:
+    from . import DiscInfo, TitleInfo
+
+
+def inspect_dvd(
+    device: str,
+    *,
+    tool: ToolAvailability,
+    runner: Runner = subprocess_run,
+) -> "DiscInfo":
+    """Inspect a DVD device using :command:`lsdvd` and return structured info."""
+
+    command = [tool.path, "-Oy", "-c", device]
+    result = runner(command, check=True, stdout=PIPE, stderr=PIPE, text=True)
+    disc_payload = _parse_lsdvd_output(result.stdout)
+    return _disc_from_payload(disc_payload)
+
+
+def _parse_lsdvd_output(output: str) -> Mapping[str, object]:
+    match = _DISC_PATTERN.search(output)
+    if not match:
+        raise ValueError("Unexpected lsdvd output; missing disc payload")
+
+    disc_dict = ast.literal_eval(match.group(1))  # nosec: controlled input from lsdvd
+    if not isinstance(disc_dict, dict):
+        raise ValueError("Parsed lsdvd payload is not a mapping")
+    return disc_dict
+
+
+def _disc_from_payload(payload: Mapping[str, object]) -> "DiscInfo":
+    from . import DiscInfo, TitleInfo
+
+    title = str(payload.get("title", "")) or "Unknown Disc"
+    tracks_data = payload.get("track")
+    titles: list[TitleInfo] = []
+
+    if isinstance(tracks_data, Mapping):
+        tracks_iter: Iterable[Mapping[str, object]] = [tracks_data]
+    elif isinstance(tracks_data, Sequence):
+        tracks_iter = [item for item in tracks_data if isinstance(item, Mapping)]
+    else:
+        tracks_iter = []
+
+    for track in sorted(tracks_iter, key=lambda item: int(item.get("ix", 0))):
+        titles.append(_title_from_track(track, TitleInfo))
+
+    return DiscInfo(label=title, titles=titles)
+
+
+def _title_from_track(
+    track: Mapping[str, object], title_cls: type["TitleInfo"],
+) -> "TitleInfo":
+    index = int(track.get("ix", 0))
+    label = f"Title {index:02d}" if index else "Title"
+    duration_text = str(track.get("length", "0"))
+    duration = _parse_duration(duration_text)
+
+    chapters_data = track.get("chapter") or track.get("chapters") or []
+    chapters: list[timedelta] = []
+    if isinstance(chapters_data, Mapping):
+        chapters_data = [chapters_data]
+    if isinstance(chapters_data, Sequence):
+        for chapter in chapters_data:
+            if isinstance(chapter, Mapping) and "length" in chapter:
+                chapters.append(_parse_duration(str(chapter["length"])))
+
+    return title_cls(label=label, duration=duration, chapters=tuple(chapters))
+
+
+def _parse_duration(value: str) -> timedelta:
+    hours = minutes = seconds = 0
+    microseconds = 0
+
+    parts = value.split(":")
+    if len(parts) == 3:
+        hours, minutes, seconds_part = parts
+    elif len(parts) == 2:
+        hours = 0
+        minutes, seconds_part = parts
+    else:
+        seconds_part = parts[0] if parts else "0"
+
+    if isinstance(hours, str):
+        hours = int(hours or 0)
+    if isinstance(minutes, str):
+        minutes = int(minutes or 0)
+
+    seconds_str, dot, fraction = seconds_part.partition(".")
+    seconds = int(seconds_str or 0)
+    if dot:
+        fraction = (fraction + "000000")[:6]
+        microseconds = int(fraction)
+
+    return timedelta(hours=hours, minutes=minutes, seconds=seconds, microseconds=microseconds)

--- a/tests/test_dvd_inspector.py
+++ b/tests/test_dvd_inspector.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from discripper.core import ToolAvailability, inspect_dvd
+
+
+SAMPLE_LSDVD_OUTPUT = """
+lsdvd output
+
+***** No VOBU entries found, assuming blank disc *****
+
+disc = {
+    'title': 'SERIES_DISC',
+    'track_count': 2,
+    'track': [
+        {
+            'ix': 1,
+            'length': '00:42:31.000',
+            'chapter_count': 2,
+            'chapter': [
+                {'ix': 1, 'length': '00:10:00.000'},
+                {'ix': 2, 'length': '00:32:31.000'},
+            ],
+        },
+        {
+            'ix': 2,
+            'length': '00:43:00.500',
+            'chapter': {'ix': 1, 'length': '00:43:00.500'},
+        },
+    ],
+}
+"""
+
+
+@pytest.fixture()
+def dvd_tool() -> ToolAvailability:
+    return ToolAvailability(command="lsdvd", path="/usr/bin/lsdvd")
+
+
+def test_inspect_dvd_parses_disc_information(dvd_tool: ToolAvailability) -> None:
+    calls: list[list[str]] = []
+
+    def fake_runner(args, **kwargs):
+        calls.append(args)
+        return SimpleNamespace(stdout=SAMPLE_LSDVD_OUTPUT, stderr="")
+
+    disc = inspect_dvd("/dev/sr0", tool=dvd_tool, runner=fake_runner)
+
+    assert calls == [["/usr/bin/lsdvd", "-Oy", "-c", "/dev/sr0"]]
+    assert disc.label == "SERIES_DISC"
+    assert len(disc.titles) == 2
+
+    first, second = disc.titles
+    assert first.label == "Title 01"
+    assert first.duration == timedelta(minutes=42, seconds=31)
+    assert first.chapters == (timedelta(minutes=10), timedelta(minutes=32, seconds=31))
+
+    assert second.label == "Title 02"
+    assert second.duration == timedelta(minutes=43, seconds=0, microseconds=500_000)
+    assert second.chapters == (timedelta(minutes=43, seconds=0, microseconds=500_000),)
+
+
+def test_inspect_dvd_errors_on_unexpected_output(dvd_tool: ToolAvailability) -> None:
+    def fake_runner(args, **kwargs):
+        return SimpleNamespace(stdout="unexpected", stderr="")
+
+    with pytest.raises(ValueError):
+        inspect_dvd("/dev/sr0", tool=dvd_tool, runner=fake_runner)


### PR DESCRIPTION
## Summary
- add an `inspect_dvd` helper that shells out to `lsdvd` and converts its output into `DiscInfo`/`TitleInfo`
- expose the adapter via `discripper.core` and exercise it with focused unit tests
- update the roadmap to mark task #P3-T3 complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e3356a5c38832183d3cb5fa865685d