### PR TITLE
#P3-T4 Implement ffprobe fallback inspector

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -29,7 +29,7 @@
 - [x] Define dataclasses `DiscInfo`, `TitleInfo` (fields for label, titles, chapters, durations) [#P3-T1]
 - [x] Implement tool discovery for `lsdvd`, `ffprobe`, and Blu-ray inspector (detect availability) [#P3-T2]
 - [x] Implement DVD inspector adapter using `lsdvd` where available (parses durations/titles) [#P3-T3]
-- [ ] Implement fallback inspector using `ffprobe` on device (best-effort title/duration extraction) [#P3-T4]
+- [x] Implement fallback inspector using `ffprobe` on device (best-effort title/duration extraction) [#P3-T4]
 - [ ] Stub Blu-ray path (documented detection; usable later) (graceful “not supported yet” message) [#P3-T5]
 - [ ] Add fake inspector loading JSON fixtures from `tests/fixtures/` (injectable for tests) [#P3-T6]
 - [ ] Error if device missing/unreadable (non-zero exit, actionable message) [#P3-T7]

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -13,6 +13,7 @@ from .discovery import (
     discover_inspection_tools,
 )
 from .dvd import inspect_dvd
+from .ffprobe import inspect_with_ffprobe
 
 __all__ = [
     "DiscInfo",
@@ -22,6 +23,7 @@ __all__ = [
     "discover_inspection_tools",
     "BLURAY_INSPECTOR_CANDIDATES",
     "inspect_dvd",
+    "inspect_with_ffprobe",
     "__version__",
 ]
 

--- a/src/discripper/core/ffprobe.py
+++ b/src/discripper/core/ffprobe.py
@@ -1,0 +1,92 @@
+"""Fallback disc inspection using :command:`ffprobe`."""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from subprocess import PIPE, CompletedProcess, run as subprocess_run
+from typing import TYPE_CHECKING, Callable
+
+from .discovery import ToolAvailability
+
+__all__ = ["inspect_with_ffprobe"]
+
+Runner = Callable[..., CompletedProcess[str]]
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from . import DiscInfo
+
+
+def inspect_with_ffprobe(
+    device: str,
+    *,
+    tool: ToolAvailability,
+    runner: Runner = subprocess_run,
+) -> "DiscInfo":
+    """Inspect a disc device using :command:`ffprobe` and return structured info."""
+
+    command = [
+        tool.path,
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration:format_tags=title",
+        "-of",
+        "json",
+        device,
+    ]
+    result = runner(command, check=True, stdout=PIPE, stderr=PIPE, text=True)
+    return _disc_from_payload(result.stdout)
+
+
+def _disc_from_payload(output: str) -> "DiscInfo":
+    from . import DiscInfo, TitleInfo
+
+    payload = _load_json(output)
+    format_info = payload.get("format") if isinstance(payload, dict) else None
+
+    label = "Unknown Disc"
+    duration = timedelta()
+
+    if isinstance(format_info, dict):
+        tags = format_info.get("tags")
+        if isinstance(tags, dict):
+            title = tags.get("title")
+            if isinstance(title, str) and title.strip():
+                label = title.strip()
+
+        duration = _parse_duration(format_info.get("duration"))
+
+    title_label = label if label != "Unknown Disc" else "Title"
+    return DiscInfo(label=label, titles=(TitleInfo(label=title_label, duration=duration),))
+
+
+def _load_json(output: str) -> dict[str, object]:
+    try:
+        payload = json.loads(output or "{}")
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise ValueError("Unexpected ffprobe output; not valid JSON") from exc
+
+    if isinstance(payload, dict):
+        return payload
+    raise ValueError("Unexpected ffprobe output; expected JSON object")
+
+
+def _parse_duration(value: object) -> timedelta:
+    if isinstance(value, (int, float)):
+        seconds = float(value)
+    elif isinstance(value, str):
+        try:
+            seconds = float(value)
+        except ValueError:
+            return timedelta()
+    else:
+        return timedelta()
+
+    seconds = max(seconds, 0.0)
+    seconds_int = int(seconds)
+    microseconds = int(round((seconds - seconds_int) * 1_000_000))
+    if microseconds >= 1_000_000:
+        seconds_int += 1
+        microseconds -= 1_000_000
+    return timedelta(seconds=seconds_int, microseconds=microseconds)

--- a/tests/test_ffprobe_inspector.py
+++ b/tests/test_ffprobe_inspector.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+import pytest
+
+from discripper.core import DiscInfo, TitleInfo
+from discripper.core.discovery import ToolAvailability
+from discripper.core.ffprobe import inspect_with_ffprobe
+
+
+class DummyCompletedProcess:
+    def __init__(self, args: list[str], stdout: str) -> None:
+        self.args = args
+        self.returncode = 0
+        self.stdout = stdout
+
+
+@pytest.fixture()
+def ffprobe_tool() -> ToolAvailability:
+    return ToolAvailability(command="ffprobe", path="/usr/bin/ffprobe")
+
+
+def test_inspect_with_ffprobe_parses_title_and_duration(ffprobe_tool: ToolAvailability) -> None:
+    payload = {
+        "format": {
+            "duration": "123.5",
+            "tags": {"title": "Sample Disc"},
+        }
+    }
+    ffprobe_output = json.dumps(payload)
+    captured_command: list[str] = []
+
+    def runner(command, check, stdout=None, stderr=None, text=None):  # type: ignore[override]
+        captured_command.extend(command)
+        return DummyCompletedProcess(command, ffprobe_output)
+
+    disc = inspect_with_ffprobe("/dev/sr0", tool=ffprobe_tool, runner=runner)
+
+    expected_command = [
+        ffprobe_tool.path,
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration:format_tags=title",
+        "-of",
+        "json",
+        "/dev/sr0",
+    ]
+    assert captured_command == expected_command
+
+    assert isinstance(disc, DiscInfo)
+    assert disc.label == "Sample Disc"
+    assert len(disc.titles) == 1
+    title = disc.titles[0]
+    assert isinstance(title, TitleInfo)
+    assert title.label == "Sample Disc"
+    assert title.duration == timedelta(seconds=123, microseconds=500000)
+
+
+def test_inspect_with_ffprobe_handles_missing_fields(ffprobe_tool: ToolAvailability) -> None:
+    ffprobe_output = json.dumps({"format": {}})
+
+    def runner(command, check, stdout=None, stderr=None, text=None):  # type: ignore[override]
+        return DummyCompletedProcess(command, ffprobe_output)
+
+    disc = inspect_with_ffprobe("/dev/sr0", tool=ffprobe_tool, runner=runner)
+
+    assert disc.label == "Unknown Disc"
+    assert len(disc.titles) == 1
+    title = disc.titles[0]
+    assert title.label == "Title"
+    assert title.duration == timedelta(0)
+
+
+def test_inspect_with_ffprobe_rejects_non_json(ffprobe_tool: ToolAvailability) -> None:
+    def runner(command, check, stdout=None, stderr=None, text=None):  # type: ignore[override]
+        return DummyCompletedProcess(command, "not-json")
+
+    with pytest.raises(ValueError):
+        inspect_with_ffprobe("/dev/sr0", tool=ffprobe_tool, runner=runner)


### PR DESCRIPTION
## Summary
- add an ffprobe-based fallback inspector that emits `DiscInfo` entries when lsdvd is unavailable
- expose the new inspector through the core package API
- cover the fallback path with focused unit tests and mark the roadmap item complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Risks / Rollback
- Low risk: new logic is isolated behind the fallback inspector. Roll back by removing `core/ffprobe.py` if issues arise.

## Task
- [#P3-T4](TASKS.md#phase-3--core-inspection--input-acquisition)

------
https://chatgpt.com/codex/tasks/task_b_68e33f39d3d48321954779cbe9773b10