### PR TITLE
[#P3-T5] Stub Blu-ray inspection placeholder

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -30,7 +30,7 @@
 - [x] Implement tool discovery for `lsdvd`, `ffprobe`, and Blu-ray inspector (detect availability) [#P3-T2]
 - [x] Implement DVD inspector adapter using `lsdvd` where available (parses durations/titles) [#P3-T3]
 - [x] Implement fallback inspector using `ffprobe` on device (best-effort title/duration extraction) [#P3-T4]
-- [ ] Stub Blu-ray path (documented detection; usable later) (graceful “not supported yet” message) [#P3-T5]
+- [x] Stub Blu-ray path (documented detection; usable later) (graceful “not supported yet” message) [#P3-T5]
 - [ ] Add fake inspector loading JSON fixtures from `tests/fixtures/` (injectable for tests) [#P3-T6]
 - [ ] Error if device missing/unreadable (non-zero exit, actionable message) [#P3-T7]
 

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Tuple
 
+from .bluray import BluRayNotSupportedError, inspect_blu_ray
 from .discovery import (
     BLURAY_INSPECTOR_CANDIDATES,
     InspectionTools,
@@ -22,7 +23,9 @@ __all__ = [
     "ToolAvailability",
     "discover_inspection_tools",
     "BLURAY_INSPECTOR_CANDIDATES",
+    "BluRayNotSupportedError",
     "inspect_dvd",
+    "inspect_blu_ray",
     "inspect_with_ffprobe",
     "__version__",
 ]

--- a/src/discripper/core/bluray.py
+++ b/src/discripper/core/bluray.py
@@ -1,0 +1,51 @@
+"""Blu-ray inspection placeholder implementation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Optional
+
+from .discovery import ToolAvailability
+
+__all__ = ["BluRayNotSupportedError", "inspect_blu_ray"]
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from subprocess import CompletedProcess
+
+    from . import DiscInfo
+
+Runner = Callable[..., "CompletedProcess[str]"]
+
+
+class BluRayNotSupportedError(RuntimeError):
+    """Error raised when Blu-ray inspection is requested."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self) -> str:  # pragma: no cover - trivial formatting
+        return self.message
+
+
+def _describe_tool(tool: Optional[ToolAvailability]) -> str:
+    if tool is None:
+        return "no Blu-ray inspection tool detected"
+
+    return f"detected {tool.command!r} at {tool.path!r}"
+
+
+def inspect_blu_ray(
+    device: str,
+    *,
+    tool: Optional[ToolAvailability],
+    runner: Optional[Runner] = None,
+) -> "DiscInfo":
+    """Placeholder Blu-ray inspector that raises a user-friendly error."""
+
+    description = _describe_tool(tool)
+    raise BluRayNotSupportedError(
+        message=(
+            "Blu-ray inspection is not supported yet in discripper; "
+            f"{description}. Requested device: {device!r}."
+        )
+    )

--- a/tests/test_bluray_stub.py
+++ b/tests/test_bluray_stub.py
@@ -1,0 +1,28 @@
+"""Tests for the Blu-ray inspection placeholder."""
+
+from __future__ import annotations
+
+import pytest
+
+from discripper.core import BluRayNotSupportedError, ToolAvailability, inspect_blu_ray
+
+
+def test_inspect_blu_ray_raises_placeholder_error() -> None:
+    tool = ToolAvailability(command="makemkvcon", path="/usr/bin/makemkvcon")
+
+    with pytest.raises(BluRayNotSupportedError) as excinfo:
+        inspect_blu_ray("/dev/sr0", tool=tool)
+
+    message = str(excinfo.value)
+    assert "Blu-ray inspection is not supported yet" in message
+    assert "makemkvcon" in message
+    assert "/dev/sr0" in message
+
+
+def test_inspect_blu_ray_handles_missing_tool() -> None:
+    with pytest.raises(BluRayNotSupportedError) as excinfo:
+        inspect_blu_ray("/dev/sr1", tool=None)
+
+    message = str(excinfo.value)
+    assert "no Blu-ray inspection tool detected" in message
+    assert "/dev/sr1" in message


### PR DESCRIPTION
## Summary
- add a placeholder Blu-ray inspector that raises a friendly not-supported message
- expose the stub through the core package API and add coverage tests
- mark the roadmap task as complete in TASKS.md

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e34171da9c83219f242d3fd2e5fde8