### PR TITLE
Validate device path before running CLI [#P3-T7]

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -32,7 +32,7 @@
 - [x] Implement fallback inspector using `ffprobe` on device (best-effort title/duration extraction) [#P3-T4]
 - [x] Stub Blu-ray path (documented detection; usable later) (graceful “not supported yet” message) [#P3-T5]
 - [x] Add fake inspector loading JSON fixtures from `tests/fixtures/` (injectable for tests) [#P3-T6]
-- [ ] Error if device missing/unreadable (non-zero exit, actionable message) [#P3-T7]
+- [x] Error if device missing/unreadable (non-zero exit, actionable message) [#P3-T7]
 
 ## Phase 4 – Core Classification / Processing Logic
 - [ ] Implement classifier per PRD thresholds (movie vs series) (returns type + episodes) [#P4-T1]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -15,10 +15,13 @@ def test_version_is_string() -> None:
     assert discripper.__version__ != ""
 
 
-def test_cli_main_prints_placeholder(capsys) -> None:
+def test_cli_main_prints_placeholder(tmp_path, capsys) -> None:
     """The CLI main function prints the placeholder usage text."""
 
-    exit_code = cli.main([])
+    device = tmp_path / "device"
+    device.write_text("ready", encoding="utf-8")
+
+    exit_code = cli.main([str(device)])
     captured = capsys.readouterr()
 
     assert exit_code == 0


### PR DESCRIPTION
## Summary
- validate the configured device path before running the CLI placeholder flow
- surface actionable errors when the device path is missing or unreadable
- extend CLI smoke tests to cover the validation logic and adjust existing expectations

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e344753de483218165c0e6357427bc