### PR TITLE
#P4-T1: Implement disc classification heuristics

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -35,7 +35,7 @@
 - [x] Error if device missing/unreadable (non-zero exit, actionable message) [#P3-T7]
 
 ## Phase 4 – Core Classification / Processing Logic
-- [ ] Implement classifier per PRD thresholds (movie vs series) (returns type + episodes) [#P4-T1]
+- [x] Implement classifier per PRD thresholds (movie vs series) (returns type + episodes) [#P4-T1]
 - [ ] Make thresholds configurable (e.g., long-title >60min, gaps <20%) (config keys respected) [#P4-T2]
 - [ ] Episode inference for series (order + s01eNN labels) (deterministic numbering) [#P4-T3]
 - [ ] Default to movie on ambiguous structure with warning (log explains heuristic) [#P4-T4]

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from typing import Tuple
 
 from .bluray import BluRayNotSupportedError, inspect_blu_ray
+from .classifier import ClassificationResult, DiscType, classify_disc
 from .discovery import (
     BLURAY_INSPECTOR_CANDIDATES,
     InspectionTools,
@@ -20,6 +21,9 @@ from .ffprobe import inspect_with_ffprobe
 __all__ = [
     "DiscInfo",
     "TitleInfo",
+    "DiscType",
+    "ClassificationResult",
+    "classify_disc",
     "InspectionTools",
     "ToolAvailability",
     "discover_inspection_tools",

--- a/src/discripper/core/classifier.py
+++ b/src/discripper/core/classifier.py
@@ -1,0 +1,95 @@
+"""Disc classification heuristics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import TYPE_CHECKING, Literal, Sequence, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - for typing only
+    from . import DiscInfo, TitleInfo
+
+DiscType = Literal["movie", "series"]
+
+
+@dataclass(frozen=True, slots=True)
+class ClassificationResult:
+    """Result of classifying a disc into movie or series content."""
+
+    disc_type: DiscType
+    episodes: Tuple[TitleInfo, ...]
+
+
+_MOVIE_MAIN_TITLE_THRESHOLD = timedelta(minutes=60)
+_MOVIE_TOTAL_RUNTIME_LIMIT = timedelta(hours=3)
+_SERIES_MIN_DURATION = timedelta(minutes=20)
+_SERIES_MAX_DURATION = timedelta(minutes=60)
+_SERIES_GAP_LIMIT = 0.2  # 20% variation allowed between episode runtimes
+
+
+def classify_disc(disc: DiscInfo) -> ClassificationResult:
+    """Classify *disc* according to PRD heuristics.
+
+    The function returns the inferred :class:`ClassificationResult`.
+    """
+
+    titles = list(disc.titles)
+    if not titles:
+        return ClassificationResult("movie", ())
+
+    episode_candidates = _series_candidates(list(enumerate(titles)))
+    if episode_candidates:
+        ordered = tuple(title for _, title in episode_candidates)
+        return ClassificationResult("series", ordered)
+
+    durations = [title.duration.total_seconds() for title in titles]
+    longest_index = max(range(len(titles)), key=durations.__getitem__)
+    longest_title = titles[longest_index]
+    total_runtime = sum(durations)
+
+    if _is_movie_candidate(longest_title, durations, total_runtime):
+        return ClassificationResult("movie", (longest_title,))
+
+    return ClassificationResult("movie", (longest_title,))
+
+
+def _is_movie_candidate(
+    longest_title: TitleInfo,
+    durations: Sequence[float],
+    total_runtime: float,
+) -> bool:
+    longest_duration = longest_title.duration
+    if longest_duration <= _MOVIE_MAIN_TITLE_THRESHOLD:
+        return False
+
+    if total_runtime > _MOVIE_TOTAL_RUNTIME_LIMIT.total_seconds():
+        return False
+
+    longest_seconds = longest_duration.total_seconds()
+    return all(
+        longest_seconds >= duration * 1.2 or duration == longest_seconds
+        for duration in durations
+    )
+
+
+def _series_candidates(
+    indexed_titles: Sequence[tuple[int, TitleInfo]],
+) -> Tuple[tuple[int, TitleInfo], ...]:
+    filtered = [
+        (index, title)
+        for index, title in indexed_titles
+        if _SERIES_MIN_DURATION <= title.duration <= _SERIES_MAX_DURATION
+    ]
+    if len(filtered) < 2:
+        return ()
+
+    seconds = [title.duration.total_seconds() for _, title in filtered]
+    average = sum(seconds) / len(seconds)
+    if average == 0:
+        return ()
+
+    max_gap = max(abs(duration - average) / average for duration in seconds)
+    if max_gap > _SERIES_GAP_LIMIT:
+        return ()
+
+    return tuple(sorted(filtered, key=lambda item: (item[1].duration, item[0])))

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,36 @@
+from datetime import timedelta
+
+from discripper.core import DiscInfo, TitleInfo, classify_disc
+
+
+def test_classify_disc_movie_selects_longest_title():
+    long_feature = TitleInfo(label="Main Feature", duration=timedelta(minutes=110))
+    extras = (
+        TitleInfo(label="Trailer", duration=timedelta(minutes=5)),
+        TitleInfo(label="Deleted Scenes", duration=timedelta(minutes=8)),
+    )
+    disc = DiscInfo(label="Sample Movie", titles=(long_feature, *extras))
+
+    result = classify_disc(disc)
+
+    assert result.disc_type == "movie"
+    assert result.episodes == (long_feature,)
+
+
+def test_classify_disc_series_detects_similar_episodes():
+    episode_titles = (
+        TitleInfo(label="Ep1", duration=timedelta(minutes=25)),
+        TitleInfo(label="Ep2", duration=timedelta(minutes=24)),
+        TitleInfo(label="Ep3", duration=timedelta(minutes=26)),
+        TitleInfo(label="Bonus", duration=timedelta(minutes=70)),
+    )
+    disc = DiscInfo(label="Sample Series", titles=episode_titles)
+
+    result = classify_disc(disc)
+
+    assert result.disc_type == "series"
+    assert result.episodes == (
+        episode_titles[1],
+        episode_titles[0],
+        episode_titles[2],
+    )


### PR DESCRIPTION
## Summary
- add a classifier module that implements the PRD movie vs series heuristics
- expose the classification API from the core package
- add unit tests covering movie and series detection and mark the roadmap task complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

------
https://chatgpt.com/codex/tasks/task_b_68e346f7b2dc8321a9642e437388343e