### PR TITLE
#P4-T2 Make classification thresholds configurable

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -36,7 +36,7 @@
 
 ## Phase 4 – Core Classification / Processing Logic
 - [x] Implement classifier per PRD thresholds (movie vs series) (returns type + episodes) [#P4-T1]
-- [ ] Make thresholds configurable (e.g., long-title >60min, gaps <20%) (config keys respected) [#P4-T2]
+- [x] Make thresholds configurable (e.g., long-title >60min, gaps <20%) (config keys respected) [#P4-T2]
 - [ ] Episode inference for series (order + s01eNN labels) (deterministic numbering) [#P4-T3]
 - [ ] Default to movie on ambiguous structure with warning (log explains heuristic) [#P4-T4]
 - [ ] Unit tests: movie-only disc fixture (classifier selects main title) [#P4-T5]

--- a/src/discripper/config.py
+++ b/src/discripper/config.py
@@ -14,6 +14,13 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "output_directory": str(Path.home() / "Videos"),
     "compression": False,
     "dry_run": False,
+    "classification": {
+        "movie_main_title_minutes": 60,
+        "movie_total_runtime_minutes": 180,
+        "series_min_duration_minutes": 20,
+        "series_max_duration_minutes": 60,
+        "series_gap_limit": 0.2,
+    },
     "naming": {
         "separator": "_",
         "lowercase": False,
@@ -27,6 +34,13 @@ CONFIG_SCHEMA: dict[str, Any] = {
     "output_directory": str,
     "compression": bool,
     "dry_run": bool,
+    "classification": {
+        "movie_main_title_minutes": (int, float),
+        "movie_total_runtime_minutes": (int, float),
+        "series_min_duration_minutes": (int, float),
+        "series_max_duration_minutes": (int, float),
+        "series_gap_limit": (int, float),
+    },
     "naming": {
         "separator": str,
         "lowercase": bool,

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -7,7 +7,13 @@ from datetime import timedelta
 from typing import Tuple
 
 from .bluray import BluRayNotSupportedError, inspect_blu_ray
-from .classifier import ClassificationResult, DiscType, classify_disc
+from .classifier import (
+    ClassificationResult,
+    ClassificationThresholds,
+    DiscType,
+    classify_disc,
+    thresholds_from_config,
+)
 from .discovery import (
     BLURAY_INSPECTOR_CANDIDATES,
     InspectionTools,
@@ -23,7 +29,9 @@ __all__ = [
     "TitleInfo",
     "DiscType",
     "ClassificationResult",
+    "ClassificationThresholds",
     "classify_disc",
+    "thresholds_from_config",
     "InspectionTools",
     "ToolAvailability",
     "discover_inspection_tools",

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,6 +1,11 @@
 from datetime import timedelta
 
-from discripper.core import DiscInfo, TitleInfo, classify_disc
+from discripper.core import (
+    DiscInfo,
+    TitleInfo,
+    classify_disc,
+    thresholds_from_config,
+)
 
 
 def test_classify_disc_movie_selects_longest_title():
@@ -34,3 +39,20 @@ def test_classify_disc_series_detects_similar_episodes():
         episode_titles[0],
         episode_titles[2],
     )
+
+
+def test_classify_disc_threshold_overrides_from_config():
+    episode_titles = (
+        TitleInfo(label="Ep1", duration=timedelta(minutes=25)),
+        TitleInfo(label="Ep2", duration=timedelta(minutes=24)),
+        TitleInfo(label="Ep3", duration=timedelta(minutes=26)),
+    )
+    disc = DiscInfo(label="Sample Series", titles=episode_titles)
+
+    thresholds = thresholds_from_config(
+        {"classification": {"series_min_duration_minutes": 30}}
+    )
+    result = classify_disc(disc, thresholds=thresholds)
+
+    assert result.disc_type == "movie"
+    assert result.episodes == (episode_titles[2],)


### PR DESCRIPTION
## Summary
- add classification threshold defaults and schema entries to the configuration loader
- allow the classifier to accept configurable thresholds and derive them from config mappings
- cover the configurable threshold behaviour with a new unit test

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Risks & Rollback
- Low risk; rollback by reverting this commit if issues arise.

## Links
- [#P4-T2](TASKS.md#L39)


------
https://chatgpt.com/codex/tasks/task_b_68e3483d80cc8321a298486602d952b2