### PR TITLE
[#P4-T5] Add classifier test using movie fixture

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -39,7 +39,7 @@
 - [x] Make thresholds configurable (e.g., long-title >60min, gaps <20%) (config keys respected) [#P4-T2]
 - [x] Episode inference for series (order + s01eNN labels) (deterministic numbering) [#P4-T3]
 - [x] Default to movie on ambiguous structure with warning (log explains heuristic) [#P4-T4]
-- [ ] Unit tests: movie-only disc fixture (classifier selects main title) [#P4-T5]
+- [x] Unit tests: movie-only disc fixture (classifier selects main title) [#P4-T5]
 - [ ] Unit tests: 6-episode fixture (classifier detects series, counts episodes) [#P4-T6]
 - [ ] Unit tests: borderline/ambiguous fixture (falls back to movie) [#P4-T7]
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -5,8 +5,20 @@ from discripper.core import (
     DiscInfo,
     TitleInfo,
     classify_disc,
+    inspect_from_fixture,
     thresholds_from_config,
 )
+
+
+def test_classify_disc_movie_fixture_selects_longest_title():
+    disc = inspect_from_fixture("sample_disc")
+
+    result = classify_disc(disc)
+
+    assert result.disc_type == "movie"
+    assert result.episodes == (disc.titles[0],)
+    assert result.episode_codes == ()
+    assert result.numbered_episodes == ()
 
 
 def test_classify_disc_movie_selects_longest_title():


### PR DESCRIPTION
## Summary
- add regression test ensuring the classifier handles the sample movie fixture
- update roadmap to mark movie-only disc fixture unit test complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

------
https://chatgpt.com/codex/tasks/task_b_68e34b8c66988321a93c23f7ff4b75b2