### PR TITLE
[#P4-T6] Add classifier test for six-episode series fixture

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -40,7 +40,7 @@
 - [x] Episode inference for series (order + s01eNN labels) (deterministic numbering) [#P4-T3]
 - [x] Default to movie on ambiguous structure with warning (log explains heuristic) [#P4-T4]
 - [x] Unit tests: movie-only disc fixture (classifier selects main title) [#P4-T5]
-- [ ] Unit tests: 6-episode fixture (classifier detects series, counts episodes) [#P4-T6]
+- [x] Unit tests: 6-episode fixture (classifier detects series, counts episodes) [#P4-T6]
 - [ ] Unit tests: borderline/ambiguous fixture (falls back to movie) [#P4-T7]
 
 ## Phase 5 – Execution / Ripping Pipeline

--- a/tests/fixtures/six_episode_series.json
+++ b/tests/fixtures/six_episode_series.json
@@ -1,0 +1,12 @@
+{
+  "label": "Six Episode Series",
+  "titles": [
+    {"label": "Episode 1", "duration": "00:24:30"},
+    {"label": "Episode 2", "duration": "00:24:45"},
+    {"label": "Episode 3", "duration": "00:24:15"},
+    {"label": "Episode 4", "duration": "00:24:50"},
+    {"label": "Episode 5", "duration": "00:24:40"},
+    {"label": "Episode 6", "duration": "00:24:35"},
+    {"label": "Bonus Feature", "duration": "01:10:00"}
+  ]
+}

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -62,6 +62,25 @@ def test_classify_disc_series_detects_similar_episodes():
     )
 
 
+def test_classify_disc_series_from_fixture_detects_all_six_episodes():
+    disc = inspect_from_fixture("six_episode_series")
+
+    result = classify_disc(disc)
+
+    assert result.disc_type == "series"
+    assert len(result.episodes) == 6
+    assert all(title.label.startswith("Episode ") for title in result.episodes)
+    assert result.episode_codes == (
+        "s01e01",
+        "s01e02",
+        "s01e03",
+        "s01e04",
+        "s01e05",
+        "s01e06",
+    )
+    assert result.numbered_episodes == tuple(zip(result.episode_codes, result.episodes))
+
+
 def test_classify_disc_threshold_overrides_from_config():
     episode_titles = (
         TitleInfo(label="Ep1", duration=timedelta(minutes=25)),


### PR DESCRIPTION
## Summary
- add a JSON fixture representing a six-episode disc
- extend classifier tests to load the fixture and assert six numbered episodes
- mark roadmap task #P4-T6 complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e34c318c8c8321a3976fd17dcdaf74