### PR TITLE
#P4-T7 Add ambiguous classification fixture test

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -41,7 +41,7 @@
 - [x] Default to movie on ambiguous structure with warning (log explains heuristic) [#P4-T4]
 - [x] Unit tests: movie-only disc fixture (classifier selects main title) [#P4-T5]
 - [x] Unit tests: 6-episode fixture (classifier detects series, counts episodes) [#P4-T6]
-- [ ] Unit tests: borderline/ambiguous fixture (falls back to movie) [#P4-T7]
+- [x] Unit tests: borderline/ambiguous fixture (falls back to movie) [#P4-T7]
 
 ## Phase 5 – Execution / Ripping Pipeline
 - [ ] Implement `rip_title(device, title_info, dest_path, *, dry_run=False)` (returns success plan) [#P5-T1]

--- a/tests/fixtures/ambiguous_disc.json
+++ b/tests/fixtures/ambiguous_disc.json
@@ -1,0 +1,8 @@
+{
+  "label": "Borderline Feature",
+  "titles": [
+    {"label": "Feature", "duration": "00:58:00"},
+    {"label": "Short Episode", "duration": "00:30:00"},
+    {"label": "Bonus", "duration": "00:12:00"}
+  ]
+}

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -116,3 +116,13 @@ def test_classify_disc_logs_warning_on_ambiguous_disc(caplog):
     warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
     assert warnings, "Expected a warning when falling back to movie classification"
     assert "Ambiguous disc structure" in warnings[0].message
+
+
+def test_classify_disc_ambiguous_fixture_defaults_to_movie():
+    disc = inspect_from_fixture("ambiguous_disc")
+
+    result = classify_disc(disc)
+
+    assert result.disc_type == "movie"
+    assert result.episodes == (disc.titles[0],)
+    assert result.episode_codes == ()


### PR DESCRIPTION
## Summary
- add an ambiguous disc JSON fixture that keeps runtimes near the movie threshold
- assert that classification falls back to movie when loading the ambiguous fixture
- mark task #P4-T7 complete in TASKS.md

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Task Reference
- [TASKS.md#L44](TASKS.md#L44)

------
https://chatgpt.com/codex/tasks/task_b_68e34cd890b08321bd16eab042882659