### PR TITLE
[#P5-T1] Add rip title planning helper

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -44,7 +44,7 @@
 - [x] Unit tests: borderline/ambiguous fixture (falls back to movie) [#P4-T7]
 
 ## Phase 5 – Execution / Ripping Pipeline
-- [ ] Implement `rip_title(device, title_info, dest_path, *, dry_run=False)` (returns success plan) [#P5-T1]
+- [x] Implement `rip_title(device, title_info, dest_path, *, dry_run=False)` (returns success plan) [#P5-T1]
 - [ ] Implement `rip_disc(...)` orchestrator for movie & series flows (iterates titles) [#P5-T2]
 - [ ] Implement `ffmpeg`-based basic ripping path (document constraints) (ffmpeg path works) [#P5-T3]
 - [ ] Detect and use `dvdbackup`/other tools if available (choose simplest successful path) [#P5-T4]

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -23,6 +23,7 @@ from .discovery import (
 from .dvd import inspect_dvd
 from .fake import inspect_from_fixture
 from .ffprobe import inspect_with_ffprobe
+from .rip import RipPlan, rip_title
 
 __all__ = [
     "DiscInfo",
@@ -41,6 +42,8 @@ __all__ = [
     "inspect_blu_ray",
     "inspect_with_ffprobe",
     "inspect_from_fixture",
+    "RipPlan",
+    "rip_title",
     "__version__",
 ]
 

--- a/src/discripper/core/rip.py
+++ b/src/discripper/core/rip.py
@@ -1,0 +1,58 @@
+"""Ripping helpers for turning inspected titles into actionable plans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from os import fspath
+from pathlib import Path
+from typing import TYPE_CHECKING, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from . import TitleInfo
+
+
+@dataclass(frozen=True, slots=True)
+class RipPlan:
+    """Structured description of how a single title should be ripped."""
+
+    device: str
+    title: "TitleInfo"
+    destination: Path
+    command: Tuple[str, ...]
+    will_execute: bool
+
+
+def rip_title(
+    device: str | Path,
+    title_info: "TitleInfo",
+    dest_path: str | Path,
+    *,
+    dry_run: bool = False,
+) -> RipPlan:
+    """Return the rip plan for ``title_info`` from ``device`` to ``dest_path``.
+
+    The function does not execute any external commands yet; it only prepares
+    the command that future tasks will run.  When ``dry_run`` is :data:`True`,
+    the plan records that the command should not be executed.
+    """
+
+    device_path = fspath(device)
+    destination = Path(dest_path)
+
+    command = (
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        device_path,
+        str(destination),
+    )
+
+    return RipPlan(
+        device=device_path,
+        title=title_info,
+        destination=destination,
+        command=command,
+        will_execute=not dry_run,
+    )

--- a/tests/test_rip.py
+++ b/tests/test_rip.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from discripper.core import RipPlan, TitleInfo, rip_title
+
+
+@pytest.fixture()
+def sample_title() -> TitleInfo:
+    return TitleInfo(label="Main Feature", duration=timedelta(minutes=95))
+
+
+def test_rip_title_builds_ffmpeg_plan(tmp_path: Path, sample_title: TitleInfo) -> None:
+    destination = tmp_path / "output.mp4"
+
+    plan = rip_title("/dev/sr0", sample_title, destination)
+
+    assert isinstance(plan, RipPlan)
+    assert plan.title is sample_title
+    assert plan.destination == destination
+    assert plan.device == "/dev/sr0"
+    assert plan.command[:5] == ("ffmpeg", "-hide_banner", "-loglevel", "error", "-i")
+    assert plan.command[-1] == str(destination)
+    assert plan.will_execute is True
+
+
+def test_rip_title_honors_dry_run_flag(tmp_path: Path, sample_title: TitleInfo) -> None:
+    plan = rip_title(tmp_path / "device.iso", sample_title, tmp_path / "out.mp4", dry_run=True)
+
+    assert plan.will_execute is False
+    assert plan.device == str(tmp_path / "device.iso")


### PR DESCRIPTION
## Summary
- add a RipPlan dataclass to describe single-title ripping actions
- implement rip_title to build an ffmpeg-based command plan while honoring dry-run mode
- cover the new behavior with unit tests and mark the roadmap task complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

------
https://chatgpt.com/codex/tasks/task_b_68e34d8e72d88321a7e552ac5c4f78ce