### PR TITLE
Implement rip_disc orchestrator (#P5-T2)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -45,7 +45,7 @@
 
 ## Phase 5 – Execution / Ripping Pipeline
 - [x] Implement `rip_title(device, title_info, dest_path, *, dry_run=False)` (returns success plan) [#P5-T1]
-- [ ] Implement `rip_disc(...)` orchestrator for movie & series flows (iterates titles) [#P5-T2]
+- [x] Implement `rip_disc(...)` orchestrator for movie & series flows (iterates titles) [#P5-T2]
 - [ ] Implement `ffmpeg`-based basic ripping path (document constraints) (ffmpeg path works) [#P5-T3]
 - [ ] Detect and use `dvdbackup`/other tools if available (choose simplest successful path) [#P5-T4]
 - [ ] Handle I/O errors with clear messages and non-zero exit codes (errors mapped) [#P5-T5]

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -23,7 +23,7 @@ from .discovery import (
 from .dvd import inspect_dvd
 from .fake import inspect_from_fixture
 from .ffprobe import inspect_with_ffprobe
-from .rip import RipPlan, rip_title
+from .rip import RipPlan, rip_disc, rip_title
 
 __all__ = [
     "DiscInfo",
@@ -43,6 +43,7 @@ __all__ = [
     "inspect_with_ffprobe",
     "inspect_from_fixture",
     "RipPlan",
+    "rip_disc",
     "rip_title",
     "__version__",
 ]

--- a/tests/test_rip.py
+++ b/tests/test_rip.py
@@ -5,7 +5,13 @@ from pathlib import Path
 
 import pytest
 
-from discripper.core import RipPlan, TitleInfo, rip_title
+from discripper.core import (
+    ClassificationResult,
+    RipPlan,
+    TitleInfo,
+    rip_disc,
+    rip_title,
+)
 
 
 @pytest.fixture()
@@ -32,3 +38,44 @@ def test_rip_title_honors_dry_run_flag(tmp_path: Path, sample_title: TitleInfo) 
 
     assert plan.will_execute is False
     assert plan.device == str(tmp_path / "device.iso")
+
+
+def test_rip_disc_movie_invokes_destination_factory(
+    tmp_path: Path, sample_title: TitleInfo
+) -> None:
+    classification = ClassificationResult("movie", (sample_title,))
+    destinations: list[Path] = []
+
+    def destination_factory(title: TitleInfo, code: str | None) -> Path:
+        assert code is None
+        assert title is sample_title
+        path = tmp_path / f"{title.label}.mp4"
+        destinations.append(path)
+        return path
+
+    plans = rip_disc("/dev/sr0", classification, destination_factory)
+
+    assert len(plans) == 1
+    assert plans[0].destination == destinations[0]
+    assert plans[0].command[-1] == str(destinations[0])
+
+
+def test_rip_disc_series_uses_episode_codes(tmp_path: Path) -> None:
+    title_one = TitleInfo(label="Pilot", duration=timedelta(minutes=45))
+    title_two = TitleInfo(label="Episode Two", duration=timedelta(minutes=44))
+    classification = ClassificationResult(
+        "series", (title_one, title_two), ("s01e01", "s01e02")
+    )
+
+    def destination_factory(title: TitleInfo, code: str | None) -> Path:
+        assert code is not None
+        return tmp_path / f"{code}_{title.label}.mp4"
+
+    plans = rip_disc("/dev/sr0", classification, destination_factory, dry_run=True)
+
+    assert len(plans) == 2
+    assert [plan.destination.name for plan in plans] == [
+        "s01e01_Pilot.mp4",
+        "s01e02_Episode Two.mp4",
+    ]
+    assert all(plan.will_execute is False for plan in plans)


### PR DESCRIPTION
## Summary
- add a `rip_disc` orchestrator that builds rip plans for each classified title via the existing `rip_title`
- export the new helper from the core package and cover movie and series flows with unit tests
- mark TASKS.md entry [#P5-T2] as complete

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`

## Risks
- Low: new function composes existing helpers without side effects.

## Rollback Plan
- Revert this PR.

## Task
- TASKS.md [#P5-T2]


------
https://chatgpt.com/codex/tasks/task_b_68e34e6dc9788321a88c8d6c9b782c25