### PR TITLE
Implement dvdbackup detection (#P5-T4)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -47,7 +47,7 @@
 - [x] Implement `rip_title(device, title_info, dest_path, *, dry_run=False)` (returns success plan) [#P5-T1]
 - [x] Implement `rip_disc(...)` orchestrator for movie & series flows (iterates titles) [#P5-T2]
 - [x] Implement `ffmpeg`-based basic ripping path (document constraints) (ffmpeg path works) [#P5-T3]
-- [ ] Detect and use `dvdbackup`/other tools if available (choose simplest successful path) [#P5-T4]
+- [x] Detect and use `dvdbackup`/other tools if available (choose simplest successful path) [#P5-T4]
 - [ ] Handle I/O errors with clear messages and non-zero exit codes (errors mapped) [#P5-T5]
 - [ ] `--dry-run` prints plan only; performs no writes (no file side-effects) [#P5-T6]
 

--- a/tests/test_rip.py
+++ b/tests/test_rip.py
@@ -22,10 +22,16 @@ def sample_title() -> TitleInfo:
     return TitleInfo(label="Main Feature", duration=timedelta(minutes=95))
 
 
+def _ffmpeg_only(cmd: str) -> str | None:
+    if cmd == "ffmpeg":
+        return "/usr/bin/ffmpeg"
+    return None
+
+
 def test_rip_title_builds_ffmpeg_plan(tmp_path: Path, sample_title: TitleInfo) -> None:
     destination = tmp_path / "output.mp4"
 
-    plan = rip_title("/dev/sr0", sample_title, destination)
+    plan = rip_title("/dev/sr0", sample_title, destination, which=_ffmpeg_only)
 
     assert isinstance(plan, RipPlan)
     assert plan.title is sample_title
@@ -37,10 +43,43 @@ def test_rip_title_builds_ffmpeg_plan(tmp_path: Path, sample_title: TitleInfo) -
 
 
 def test_rip_title_honors_dry_run_flag(tmp_path: Path, sample_title: TitleInfo) -> None:
-    plan = rip_title(tmp_path / "device.iso", sample_title, tmp_path / "out.mp4", dry_run=True)
+    plan = rip_title(
+        tmp_path / "device.iso",
+        sample_title,
+        tmp_path / "out.mp4",
+        dry_run=True,
+        which=_ffmpeg_only,
+    )
 
     assert plan.will_execute is False
     assert plan.device == str(tmp_path / "device.iso")
+
+
+def test_rip_title_prefers_dvdbackup_when_available(
+    tmp_path: Path, sample_title: TitleInfo
+) -> None:
+    destination = tmp_path / "movie.mp4"
+
+    def fake_which(command: str) -> str | None:
+        if command == "dvdbackup":
+            return "/usr/bin/dvdbackup"
+        if command == "ffmpeg":
+            return "/usr/bin/ffmpeg"
+        return None
+
+    plan = rip_title("/dev/sr0", sample_title, destination, which=fake_which)
+
+    assert plan.command[0] == "dvdbackup"
+    assert "-i" in plan.command
+    assert plan.destination == destination
+
+
+def test_rip_title_errors_without_known_tools(tmp_path: Path, sample_title: TitleInfo) -> None:
+    def fake_which(command: str) -> None:
+        return None
+
+    with pytest.raises(RuntimeError, match="No supported ripping tools"):
+        rip_title("/dev/sr0", sample_title, tmp_path / "out.mp4", which=fake_which)
 
 
 def test_rip_disc_movie_invokes_destination_factory(
@@ -56,7 +95,12 @@ def test_rip_disc_movie_invokes_destination_factory(
         destinations.append(path)
         return path
 
-    plans = rip_disc("/dev/sr0", classification, destination_factory)
+    plans = rip_disc(
+        "/dev/sr0",
+        classification,
+        destination_factory,
+        which=_ffmpeg_only,
+    )
 
     assert len(plans) == 1
     assert plans[0].destination == destinations[0]
@@ -74,7 +118,13 @@ def test_rip_disc_series_uses_episode_codes(tmp_path: Path) -> None:
         assert code is not None
         return tmp_path / f"{code}_{title.label}.mp4"
 
-    plans = rip_disc("/dev/sr0", classification, destination_factory, dry_run=True)
+    plans = rip_disc(
+        "/dev/sr0",
+        classification,
+        destination_factory,
+        dry_run=True,
+        which=_ffmpeg_only,
+    )
 
     assert len(plans) == 2
     assert [plan.destination.name for plan in plans] == [
@@ -85,7 +135,12 @@ def test_rip_disc_series_uses_episode_codes(tmp_path: Path) -> None:
 
 
 def test_run_rip_plan_invokes_subprocess(tmp_path: Path, sample_title: TitleInfo) -> None:
-    plan = rip_title(tmp_path / "device.iso", sample_title, tmp_path / "out.mp4")
+    plan = rip_title(
+        tmp_path / "device.iso",
+        sample_title,
+        tmp_path / "out.mp4",
+        which=_ffmpeg_only,
+    )
 
     calls: list[tuple[tuple[str, ...], bool]] = []
 
@@ -106,6 +161,7 @@ def test_run_rip_plan_skips_dry_run(tmp_path: Path, sample_title: TitleInfo) -> 
         sample_title,
         tmp_path / "out.mp4",
         dry_run=True,
+        which=_ffmpeg_only,
     )
 
     def fake_run(command: tuple[str, ...], check: bool) -> CompletedProcess[str]:


### PR DESCRIPTION
## Summary
- choose the available ripping command by preferring `dvdbackup` and falling back to `ffmpeg`
- allow dependency injection of the tool discovery helper and refresh the ripper docstring
- extend rip unit tests to cover tool selection, error handling, and deterministic behaviour; mark roadmap item complete

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`

## Risks
- Minimal: selecting `dvdbackup` changes the planned command shape when the tool exists on PATH.

## Rollback Plan
- Revert commit `[feat] Prefer dvdbackup when available`.

## Task
- TASKS.md (#P5-T4)

------
https://chatgpt.com/codex/tasks/task_b_68e354f31d0883219d40c2b95dbbd27a