### PR TITLE
[#P5-T5] Map ripping I/O failures to exit codes

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -48,7 +48,7 @@
 - [x] Implement `rip_disc(...)` orchestrator for movie & series flows (iterates titles) [#P5-T2]
 - [x] Implement `ffmpeg`-based basic ripping path (document constraints) (ffmpeg path works) [#P5-T3]
 - [x] Detect and use `dvdbackup`/other tools if available (choose simplest successful path) [#P5-T4]
-- [ ] Handle I/O errors with clear messages and non-zero exit codes (errors mapped) [#P5-T5]
+- [x] Handle I/O errors with clear messages and non-zero exit codes (errors mapped) [#P5-T5]
 - [ ] `--dry-run` prints plan only; performs no writes (no file side-effects) [#P5-T6]
 
 ## Phase 6 – Naming & Organization

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -23,7 +23,7 @@ from .discovery import (
 from .dvd import inspect_dvd
 from .fake import inspect_from_fixture
 from .ffprobe import inspect_with_ffprobe
-from .rip import RipPlan, rip_disc, rip_title, run_rip_plan
+from .rip import RipExecutionError, RipPlan, rip_disc, rip_title, run_rip_plan
 
 __all__ = [
     "DiscInfo",
@@ -42,6 +42,7 @@ __all__ = [
     "inspect_blu_ray",
     "inspect_with_ffprobe",
     "inspect_from_fixture",
+    "RipExecutionError",
     "RipPlan",
     "rip_disc",
     "rip_title",


### PR DESCRIPTION
## Summary
- add a RipExecutionError exception for wrapping external command failures
- update run_rip_plan to surface actionable error messages with exit code mapping
- extend rip execution tests and check off TASKS.md item for #P5-T5

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`

## Risks
- Low: additional exception wrapping could hide unexpected subprocess details if new errors occur.

## Rollback Plan
- Revert this PR.

## Evidence
- Task: TASKS.md (#P5-T5)


------
https://chatgpt.com/codex/tasks/task_b_68e35756a9ec8321b45b1e1b59ea89c0