### PR TITLE
#P5-T6 Print dry-run rip plans

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -49,7 +49,7 @@
 - [x] Implement `ffmpeg`-based basic ripping path (document constraints) (ffmpeg path works) [#P5-T3]
 - [x] Detect and use `dvdbackup`/other tools if available (choose simplest successful path) [#P5-T4]
 - [x] Handle I/O errors with clear messages and non-zero exit codes (errors mapped) [#P5-T5]
-- [ ] `--dry-run` prints plan only; performs no writes (no file side-effects) [#P5-T6]
+- [x] `--dry-run` prints plan only; performs no writes (no file side-effects) [#P5-T6]
 
 ## Phase 6 – Naming & Organization
 - [ ] Implement ASCII/unsafe char sanitization; use `naming.separator` (sanitizer unit-tested) [#P6-T1]

--- a/src/discripper/core/rip.py
+++ b/src/discripper/core/rip.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from collections.abc import Callable
 from dataclasses import dataclass
 from os import fspath
@@ -128,6 +129,7 @@ def run_rip_plan(
     """
 
     if not plan.will_execute:
+        print(f"[dry-run] Would execute: {shlex.join(plan.command)}")
         return None
 
     try:

--- a/tests/test_rip.py
+++ b/tests/test_rip.py
@@ -156,7 +156,9 @@ def test_run_rip_plan_invokes_subprocess(tmp_path: Path, sample_title: TitleInfo
     assert result.returncode == 0
 
 
-def test_run_rip_plan_skips_dry_run(tmp_path: Path, sample_title: TitleInfo) -> None:
+def test_run_rip_plan_skips_dry_run(
+    tmp_path: Path, sample_title: TitleInfo, capsys
+) -> None:
     plan = rip_title(
         tmp_path / "device.iso",
         sample_title,
@@ -171,6 +173,10 @@ def test_run_rip_plan_skips_dry_run(tmp_path: Path, sample_title: TitleInfo) -> 
     result = run_rip_plan(plan, run=fake_run)
 
     assert result is None
+
+    captured = capsys.readouterr()
+    assert "[dry-run] Would execute:" in captured.out
+    assert str(plan.destination) in captured.out
 
 
 def test_run_rip_plan_maps_called_process_error(


### PR DESCRIPTION
## Summary
- log the rip command that would run when a plan is executed in dry-run mode so users see the intended action
- extend the dry-run unit test to assert the informational output is emitted
- mark TASKS.md entry #P5-T6 complete

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`

## Risks & Rollback
- Low risk: change only touches dry-run logging and associated test.
- Rollback by reverting commit [feat] Print dry-run rip plans.

## References
- Task: [#P5-T6](TASKS.md)


------
https://chatgpt.com/codex/tasks/task_b_68e358b14a4483218d38dcdf086e7ee6