### PR TITLE
#P6-T1 Implement filename sanitization

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -52,7 +52,7 @@
 - [x] `--dry-run` prints plan only; performs no writes (no file side-effects) [#P5-T6]
 
 ## Phase 6 – Naming & Organization
-- [ ] Implement ASCII/unsafe char sanitization; use `naming.separator` (sanitizer unit-tested) [#P6-T1]
+- [x] Implement ASCII/unsafe char sanitization; use `naming.separator` (sanitizer unit-tested) [#P6-T1]
 - [ ] Implement `naming.lowercase` transformation (filenames & dirs reflect flag) [#P6-T2]
 - [ ] Movie pattern: `<movieTitle>.mp4` in configured output dir (file path correct) [#P6-T3]
 - [ ] Series pattern: `<seriesName>/<seriesName>-s01eNN_<title>.mp4` (path shape correct) [#P6-T4]

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -23,6 +23,7 @@ from .discovery import (
 from .dvd import inspect_dvd
 from .fake import inspect_from_fixture
 from .ffprobe import inspect_with_ffprobe
+from .naming import sanitize_component
 from .rip import RipExecutionError, RipPlan, rip_disc, rip_title, run_rip_plan
 
 __all__ = [
@@ -42,6 +43,7 @@ __all__ = [
     "inspect_blu_ray",
     "inspect_with_ffprobe",
     "inspect_from_fixture",
+    "sanitize_component",
     "RipExecutionError",
     "RipPlan",
     "rip_disc",

--- a/src/discripper/core/naming.py
+++ b/src/discripper/core/naming.py
@@ -1,0 +1,56 @@
+"""Utilities for creating filesystem-safe names from disc metadata."""
+from __future__ import annotations
+
+import string
+import unicodedata
+
+__all__ = ["sanitize_component"]
+
+_SAFE_CHARS = set(string.ascii_letters + string.digits)
+_FALLBACK_NAME = "untitled"
+_FALLBACK_SEPARATOR = "_"
+
+
+def _normalize_separator(separator: str) -> str:
+    """Return a single ASCII character usable as a separator."""
+
+    if not separator:
+        return _FALLBACK_SEPARATOR
+
+    normalized = unicodedata.normalize("NFKD", separator)
+    ascii_only = normalized.encode("ascii", "ignore").decode("ascii")
+
+    for char in ascii_only:
+        if char in _SAFE_CHARS or char in "-_":
+            return char
+
+    return _FALLBACK_SEPARATOR
+
+
+def sanitize_component(value: str, *, separator: str = _FALLBACK_SEPARATOR) -> str:
+    """Return *value* normalized for safe filesystem usage.
+
+    The sanitizer enforces ASCII output by stripping diacritics and removing
+    characters that are not alphanumeric. Replaced characters collapse into the
+    configured *separator*. Consecutive separators are reduced to a single
+    instance and trimmed from the ends. When the sanitized value would be empty,
+    a fallback name is returned to keep downstream paths valid.
+    """
+
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_only = normalized.encode("ascii", "ignore").decode("ascii")
+    safe_separator = _normalize_separator(separator)
+
+    pieces: list[str] = []
+    previous_was_separator = False
+    for char in ascii_only:
+        if char in _SAFE_CHARS:
+            pieces.append(char)
+            previous_was_separator = False
+        else:
+            if not previous_was_separator:
+                pieces.append(safe_separator)
+                previous_was_separator = True
+
+    sanitized = "".join(pieces).strip(safe_separator)
+    return sanitized or _FALLBACK_NAME

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,26 @@
+from discripper.core import sanitize_component
+
+
+def test_sanitize_component_replaces_unsafe_characters() -> None:
+    sanitized = sanitize_component("Firefly: Serenity/Part 1")
+    assert sanitized == "Firefly_Serenity_Part_1"
+
+
+def test_sanitize_component_strips_diacritics() -> None:
+    sanitized = sanitize_component("Café del Mar")
+    assert sanitized == "Cafe_del_Mar"
+
+
+def test_sanitize_component_honors_custom_separator() -> None:
+    sanitized = sanitize_component("Episode 01", separator="-")
+    assert sanitized == "Episode-01"
+
+
+def test_sanitize_component_collapses_repeated_separators() -> None:
+    sanitized = sanitize_component("  --  odd***name  ")
+    assert sanitized == "odd_name"
+
+
+def test_sanitize_component_returns_fallback_when_empty() -> None:
+    sanitized = sanitize_component("@@@@")
+    assert sanitized == "untitled"


### PR DESCRIPTION
## Summary
- add a filesystem-safe naming sanitizer that normalizes input to ASCII and respects the configured separator
- expose the sanitizer via the core package and cover edge cases with targeted unit tests
- mark task #P6-T1 as complete in TASKS.md

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Task
- #P6-T1 (TASKS.md)


------
https://chatgpt.com/codex/tasks/task_b_68e3599733348321b2ebbf74e24e0b13