### PR TITLE
Implement naming lowercase transformation (#P6-T2)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -53,7 +53,7 @@
 
 ## Phase 6 – Naming & Organization
 - [x] Implement ASCII/unsafe char sanitization; use `naming.separator` (sanitizer unit-tested) [#P6-T1]
-- [ ] Implement `naming.lowercase` transformation (filenames & dirs reflect flag) [#P6-T2]
+- [x] Implement `naming.lowercase` transformation (filenames & dirs reflect flag) [#P6-T2]
 - [ ] Movie pattern: `<movieTitle>.mp4` in configured output dir (file path correct) [#P6-T3]
 - [ ] Series pattern: `<seriesName>/<seriesName>-s01eNN_<title>.mp4` (path shape correct) [#P6-T4]
 - [ ] Collision handling appends suffix `_1`, `_2`, … (no overwrite occurs) [#P6-T5]

--- a/src/discripper/core/naming.py
+++ b/src/discripper/core/naming.py
@@ -27,14 +27,21 @@ def _normalize_separator(separator: str) -> str:
     return _FALLBACK_SEPARATOR
 
 
-def sanitize_component(value: str, *, separator: str = _FALLBACK_SEPARATOR) -> str:
+def sanitize_component(
+    value: str,
+    *,
+    separator: str = _FALLBACK_SEPARATOR,
+    lowercase: bool = False,
+) -> str:
     """Return *value* normalized for safe filesystem usage.
 
     The sanitizer enforces ASCII output by stripping diacritics and removing
     characters that are not alphanumeric. Replaced characters collapse into the
     configured *separator*. Consecutive separators are reduced to a single
     instance and trimmed from the ends. When the sanitized value would be empty,
-    a fallback name is returned to keep downstream paths valid.
+    a fallback name is returned to keep downstream paths valid. Set
+    :param:`lowercase` to :data:`True` when the resulting component should be
+    normalized to lowercase for case-insensitive filesystems.
     """
 
     normalized = unicodedata.normalize("NFKD", value)
@@ -53,4 +60,9 @@ def sanitize_component(value: str, *, separator: str = _FALLBACK_SEPARATOR) -> s
                 previous_was_separator = True
 
     sanitized = "".join(pieces).strip(safe_separator)
-    return sanitized or _FALLBACK_NAME
+    result = sanitized or _FALLBACK_NAME
+
+    if lowercase:
+        return result.lower()
+
+    return result

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -24,3 +24,8 @@ def test_sanitize_component_collapses_repeated_separators() -> None:
 def test_sanitize_component_returns_fallback_when_empty() -> None:
     sanitized = sanitize_component("@@@@")
     assert sanitized == "untitled"
+
+
+def test_sanitize_component_applies_lowercase_when_requested() -> None:
+    sanitized = sanitize_component("Firefly: Serenity", lowercase=True)
+    assert sanitized == "firefly_serenity"


### PR DESCRIPTION
## Summary
- extend `sanitize_component` with a `lowercase` option to support the `naming.lowercase` flag
- ensure sanitized components are lowercased on demand and document the parameter
- add unit coverage and mark the roadmap task complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e35b2e5f2083218cd2dfcd394d4ff5