### PR TITLE
[#P6-T3] Implement movie naming pattern

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -54,7 +54,7 @@
 ## Phase 6 – Naming & Organization
 - [x] Implement ASCII/unsafe char sanitization; use `naming.separator` (sanitizer unit-tested) [#P6-T1]
 - [x] Implement `naming.lowercase` transformation (filenames & dirs reflect flag) [#P6-T2]
-- [ ] Movie pattern: `<movieTitle>.mp4` in configured output dir (file path correct) [#P6-T3]
+- [x] Movie pattern: `<movieTitle>.mp4` in configured output dir (file path correct) [#P6-T3]
 - [ ] Series pattern: `<seriesName>/<seriesName>-s01eNN_<title>.mp4` (path shape correct) [#P6-T4]
 - [ ] Collision handling appends suffix `_1`, `_2`, … (no overwrite occurs) [#P6-T5]
 - [ ] Ensure parent directories are created as needed (dirs created automatically) [#P6-T6]

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -23,7 +23,7 @@ from .discovery import (
 from .dvd import inspect_dvd
 from .fake import inspect_from_fixture
 from .ffprobe import inspect_with_ffprobe
-from .naming import sanitize_component
+from .naming import movie_output_path, sanitize_component
 from .rip import RipExecutionError, RipPlan, rip_disc, rip_title, run_rip_plan
 
 __all__ = [
@@ -44,6 +44,7 @@ __all__ = [
     "inspect_with_ffprobe",
     "inspect_from_fixture",
     "sanitize_component",
+    "movie_output_path",
     "RipExecutionError",
     "RipPlan",
     "rip_disc",

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,4 +1,7 @@
-from discripper.core import sanitize_component
+from datetime import timedelta
+from pathlib import Path
+
+from discripper.core import TitleInfo, movie_output_path, sanitize_component
 
 
 def test_sanitize_component_replaces_unsafe_characters() -> None:
@@ -29,3 +32,24 @@ def test_sanitize_component_returns_fallback_when_empty() -> None:
 def test_sanitize_component_applies_lowercase_when_requested() -> None:
     sanitized = sanitize_component("Firefly: Serenity", lowercase=True)
     assert sanitized == "firefly_serenity"
+
+
+def test_movie_output_path_uses_configured_directory(tmp_path: Path) -> None:
+    title = TitleInfo(label="The Matrix", duration=timedelta(minutes=136))
+    config = {
+        "output_directory": str(tmp_path / "Movies"),
+        "naming": {"separator": "-", "lowercase": True},
+    }
+
+    path = movie_output_path(title, config)
+
+    assert path == tmp_path / "Movies" / "the-matrix.mp4"
+
+
+def test_movie_output_path_defaults_without_naming_section(tmp_path: Path) -> None:
+    title = TitleInfo(label="Strange: Name", duration=timedelta(minutes=90))
+    config = {"output_directory": tmp_path}
+
+    path = movie_output_path(title, config)
+
+    assert path.name == "Strange_Name.mp4"


### PR DESCRIPTION
## Summary
- add a movie output path helper that honors configured directory and naming options
- expose the helper via the core package and cover it with new unit tests
- mark task #P6-T3 as completed in the roadmap

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

------
https://chatgpt.com/codex/tasks/task_b_68e35c30f36083219a5250927b99fb48