### PR TITLE
Implement series naming output path [#P6-T4]

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -55,7 +55,7 @@
 - [x] Implement ASCII/unsafe char sanitization; use `naming.separator` (sanitizer unit-tested) [#P6-T1]
 - [x] Implement `naming.lowercase` transformation (filenames & dirs reflect flag) [#P6-T2]
 - [x] Movie pattern: `<movieTitle>.mp4` in configured output dir (file path correct) [#P6-T3]
-- [ ] Series pattern: `<seriesName>/<seriesName>-s01eNN_<title>.mp4` (path shape correct) [#P6-T4]
+- [x] Series pattern: `<seriesName>/<seriesName>-s01eNN_<title>.mp4` (path shape correct) [#P6-T4]
 - [ ] Collision handling appends suffix `_1`, `_2`, … (no overwrite occurs) [#P6-T5]
 - [ ] Ensure parent directories are created as needed (dirs created automatically) [#P6-T6]
 

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -23,7 +23,7 @@ from .discovery import (
 from .dvd import inspect_dvd
 from .fake import inspect_from_fixture
 from .ffprobe import inspect_with_ffprobe
-from .naming import movie_output_path, sanitize_component
+from .naming import movie_output_path, sanitize_component, series_output_path
 from .rip import RipExecutionError, RipPlan, rip_disc, rip_title, run_rip_plan
 
 __all__ = [
@@ -45,6 +45,7 @@ __all__ = [
     "inspect_from_fixture",
     "sanitize_component",
     "movie_output_path",
+    "series_output_path",
     "RipExecutionError",
     "RipPlan",
     "rip_disc",

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,7 +1,12 @@
 from datetime import timedelta
 from pathlib import Path
 
-from discripper.core import TitleInfo, movie_output_path, sanitize_component
+from discripper.core import (
+    TitleInfo,
+    movie_output_path,
+    sanitize_component,
+    series_output_path,
+)
 
 
 def test_sanitize_component_replaces_unsafe_characters() -> None:
@@ -53,3 +58,30 @@ def test_movie_output_path_defaults_without_naming_section(tmp_path: Path) -> No
     path = movie_output_path(title, config)
 
     assert path.name == "Strange_Name.mp4"
+
+
+def test_series_output_path_creates_nested_structure(tmp_path: Path) -> None:
+    title = TitleInfo(label="The Long Night", duration=timedelta(minutes=52))
+    config = {
+        "output_directory": tmp_path / "Series",
+        "naming": {"separator": "-", "lowercase": True},
+    }
+
+    path = series_output_path("Game of Thrones", title, "s01e03", config)
+
+    expected = (
+        tmp_path
+        / "Series"
+        / "game-of-thrones"
+        / "game-of-thrones-s01e03_the-long-night.mp4"
+    )
+    assert path == expected
+
+
+def test_series_output_path_defaults_without_naming_section(tmp_path: Path) -> None:
+    title = TitleInfo(label="Episode #2", duration=timedelta(minutes=48))
+    config = {"output_directory": tmp_path}
+
+    path = series_output_path("Strange Show", title, "s01e02", config)
+
+    assert path == tmp_path / "Strange_Show" / "Strange_Show-s01e02_Episode_2.mp4"


### PR DESCRIPTION
## Summary
- add reusable helpers to derive naming preferences and output directory
- implement series_output_path to build `<series>/<series-code_title>.mp4` destinations
- extend naming tests and mark the roadmap task complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

------
https://chatgpt.com/codex/tasks/task_b_68e35d66b2788321bbde84ed9aeeb5a5