### PR TITLE
Ensure rip plan creates parent directories (#P6-T6)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -57,7 +57,7 @@
 - [x] Movie pattern: `<movieTitle>.mp4` in configured output dir (file path correct) [#P6-T3]
 - [x] Series pattern: `<seriesName>/<seriesName>-s01eNN_<title>.mp4` (path shape correct) [#P6-T4]
 - [x] Collision handling appends suffix `_1`, `_2`, … (no overwrite occurs) [#P6-T5]
-- [ ] Ensure parent directories are created as needed (dirs created automatically) [#P6-T6]
+- [x] Ensure parent directories are created as needed (dirs created automatically) [#P6-T6]
 
 ## Phase 7 – Orchestration, Logging, Error Handling
 - [ ] CLI main flow: config → inspect → classify → plan → rip (end-to-end path executes) [#P7-T1]

--- a/src/discripper/core/rip.py
+++ b/src/discripper/core/rip.py
@@ -132,6 +132,8 @@ def run_rip_plan(
         print(f"[dry-run] Would execute: {shlex.join(plan.command)}")
         return None
 
+    plan.destination.parent.mkdir(parents=True, exist_ok=True)
+
     try:
         return run(plan.command, check=True)
     except FileNotFoundError as exc:  # pragma: no cover - defensive on Python <3.11

--- a/tests/test_rip.py
+++ b/tests/test_rip.py
@@ -156,6 +156,24 @@ def test_run_rip_plan_invokes_subprocess(tmp_path: Path, sample_title: TitleInfo
     assert result.returncode == 0
 
 
+def test_run_rip_plan_creates_parent_directories(tmp_path: Path, sample_title: TitleInfo) -> None:
+    destination = tmp_path / "sub" / "folder" / "out.mp4"
+    plan = rip_title(
+        tmp_path / "device.iso",
+        sample_title,
+        destination,
+        which=_ffmpeg_only,
+    )
+
+    def fake_run(command: tuple[str, ...], check: bool) -> CompletedProcess[str]:
+        assert destination.parent.exists()
+        return CompletedProcess(command, 0)
+
+    result = run_rip_plan(plan, run=fake_run)
+
+    assert isinstance(result, CompletedProcess)
+
+
 def test_run_rip_plan_skips_dry_run(
     tmp_path: Path, sample_title: TitleInfo, capsys
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure rip execution creates parent directories before invoking external tools
- add a regression test covering nested destination paths
- mark roadmap task #P6-T6 as complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e3b5c8eb9c83219c2eb0a1e38945be