### PR TITLE
[P7-T1] Wire CLI main pipeline

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -60,7 +60,7 @@
 - [x] Ensure parent directories are created as needed (dirs created automatically) [#P6-T6]
 
 ## Phase 7 – Orchestration, Logging, Error Handling
-- [ ] CLI main flow: config → inspect → classify → plan → rip (end-to-end path executes) [#P7-T1]
+- [x] CLI main flow: config → inspect → classify → plan → rip (end-to-end path executes) [#P7-T1]
 - [ ] Structured logs: classification summary (e.g., `EVENT=CLASSIFIED TYPE=series EPISODES=6`) [#P7-T2]
 - [ ] Structured logs: rip results per file (e.g., `EVENT=RIP_DONE FILE=... BYTES=...`) [#P7-T3]
 - [ ] Exit codes: 1=disc not detected, 2=rip failed, etc. (documented; enforced) [#P7-T4]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -15,17 +15,23 @@ def test_version_is_string() -> None:
     assert discripper.__version__ != ""
 
 
-def test_cli_main_prints_placeholder(tmp_path, capsys) -> None:
-    """The CLI main function prints the placeholder usage text."""
+def test_cli_main_errors_without_inspection_tools(tmp_path, monkeypatch, capsys) -> None:
+    """The CLI reports a helpful error when no inspection tools are available."""
 
     device = tmp_path / "device"
     device.write_text("ready", encoding="utf-8")
 
+    monkeypatch.setattr(
+        cli,
+        "discover_inspection_tools",
+        lambda: core.InspectionTools(dvd=None, fallback=None, blu_ray=None),
+    )
+
     exit_code = cli.main([str(device)])
     captured = capsys.readouterr()
 
-    assert exit_code == 0
-    assert "Usage: discripper" in captured.out
+    assert exit_code == 1
+    assert "No supported inspection tools" in captured.err
 
 
 def test_core_version_is_exposed() -> None:


### PR DESCRIPTION
## Summary
- route the CLI through discovery, inspection, classification, planning, and ripping helpers for an end-to-end flow
- add targeted CLI tests covering dvd/ffprobe discovery, dry-run behaviour, and series naming along with updated smoke test expectations
- tick the roadmap item for the CLI orchestration task

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`

## Risks
- behaviour depends on available external tools; mismatched environments could surface new runtime errors

## Rollback Plan
- revert commit [feat] Wire CLI main pipeline

## Task
- TASKS.md (#P7-T1)


------
https://chatgpt.com/codex/tasks/task_b_68e3b83dcd408321b03183d60051583f