### PR TITLE
[#P7-T3] Add structured rip result logging

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -62,7 +62,7 @@
 ## Phase 7 – Orchestration, Logging, Error Handling
 - [x] CLI main flow: config → inspect → classify → plan → rip (end-to-end path executes) [#P7-T1]
 - [x] Structured logs: classification summary (e.g., `EVENT=CLASSIFIED TYPE=series EPISODES=6`) [#P7-T2]
-- [ ] Structured logs: rip results per file (e.g., `EVENT=RIP_DONE FILE=... BYTES=...`) [#P7-T3]
+- [x] Structured logs: rip results per file (e.g., `EVENT=RIP_DONE FILE=... BYTES=...`) [#P7-T3]
 - [ ] Exit codes: 1=disc not detected, 2=rip failed, etc. (documented; enforced) [#P7-T4]
 - [ ] Prompt/guard only when destructive overwrite would occur (safe default) [#P7-T5]
 - [ ] Centralize exceptions → user-friendly messages (no raw tracebacks by default) [#P7-T6]


### PR DESCRIPTION
## Summary
- add structured logging for rip execution results, including success, dry-run skips, and failures
- compute written byte size when available and include it in log output
- extend rip unit tests to assert structured log records and mark the task complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e3be0b69a4832183a0ee23cf976020