### PR TITLE
[#P8-T1] Add single movie disc fixture

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -68,7 +68,7 @@
 - [x] Centralize exceptions → user-friendly messages (no raw tracebacks by default) [#P7-T6]
 
 ## Phase 8 – Tests & Fixtures
-- [ ] Add fixtures: single-movie disc JSON (titles + durations) (file present) [#P8-T1]
+- [x] Add fixtures: single-movie disc JSON (titles + durations) (file present) [#P8-T1]
 - [ ] Add fixtures: multi-episode disc JSON (6 episodes) (file present) [#P8-T2]
 - [ ] Add fixtures: ambiguous structure JSON (borderline durations) (file present) [#P8-T3]
 - [ ] Tests: config precedence (defaults/config/CLI) (pytest passes) [#P8-T4]

--- a/tests/fixtures/single_movie_disc.json
+++ b/tests/fixtures/single_movie_disc.json
@@ -1,0 +1,28 @@
+{
+  "label": "Single Movie Feature",
+  "titles": [
+    {
+      "label": "Main Feature",
+      "duration": "01:52:30",
+      "chapters": [
+        "00:25:00",
+        "00:23:30",
+        "00:24:15",
+        "00:39:45"
+      ]
+    },
+    {
+      "label": "Deleted Scenes",
+      "duration": "00:15:00",
+      "chapters": [
+        "00:05:00",
+        "00:05:00",
+        "00:05:00"
+      ]
+    },
+    {
+      "label": "Theatrical Trailer",
+      "duration": "00:02:30"
+    }
+  ]
+}

--- a/tests/test_fake_inspector.py
+++ b/tests/test_fake_inspector.py
@@ -32,6 +32,36 @@ def test_inspect_from_fixture_loads_sample_fixture() -> None:
     )
 
 
+def test_inspect_from_fixture_loads_single_movie_fixture() -> None:
+    disc = inspect_from_fixture("single_movie_disc")
+
+    assert disc.label == "Single Movie Feature"
+    assert len(disc.titles) == 3
+
+    main_feature, deleted_scenes, trailer = disc.titles
+
+    assert main_feature.label == "Main Feature"
+    assert main_feature.duration == timedelta(hours=1, minutes=52, seconds=30)
+    assert main_feature.chapters == (
+        timedelta(minutes=25),
+        timedelta(minutes=23, seconds=30),
+        timedelta(minutes=24, seconds=15),
+        timedelta(minutes=39, seconds=45),
+    )
+
+    assert deleted_scenes.label == "Deleted Scenes"
+    assert deleted_scenes.duration == timedelta(minutes=15)
+    assert deleted_scenes.chapters == (
+        timedelta(minutes=5),
+        timedelta(minutes=5),
+        timedelta(minutes=5),
+    )
+
+    assert trailer.label == "Theatrical Trailer"
+    assert trailer.duration == timedelta(minutes=2, seconds=30)
+    assert trailer.chapters == ()
+
+
 def test_inspect_from_fixture_accepts_custom_directory(tmp_path: Path) -> None:
     fixture_path = tmp_path / "custom.json"
     fixture_path.write_text(


### PR DESCRIPTION
## Summary
- add a single-movie disc JSON fixture with titles and durations for reuse in tests
- extend fake inspector tests to cover the new fixture loading behavior
- mark the roadmap item for the single-movie fixture as complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e3c8ddd3e083218a3426caa293ad4c