### PR TITLE
#P8-T3 Add ambiguous disc fixture

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -70,7 +70,7 @@
 ## Phase 8 – Tests & Fixtures
 - [x] Add fixtures: single-movie disc JSON (titles + durations) (file present) [#P8-T1]
 - [x] Add fixtures: multi-episode disc JSON (6 episodes) (file present) [#P8-T2]
-- [ ] Add fixtures: ambiguous structure JSON (borderline durations) (file present) [#P8-T3]
+- [x] Add fixtures: ambiguous structure JSON (borderline durations) (file present) [#P8-T3]
 - [ ] Tests: config precedence (defaults/config/CLI) (pytest passes) [#P8-T4]
 - [ ] Tests: classification across all fixtures (pass; deterministic) [#P8-T5]
 - [ ] Tests: naming sanitization & lowercase options (pass) [#P8-T6]

--- a/tests/fixtures/ambiguous_disc.json
+++ b/tests/fixtures/ambiguous_disc.json
@@ -1,8 +1,34 @@
 {
   "label": "Borderline Feature",
   "titles": [
-    {"label": "Feature", "duration": "00:58:00"},
-    {"label": "Short Episode", "duration": "00:30:00"},
-    {"label": "Bonus", "duration": "00:12:00"}
+    {
+      "label": "Borderline Feature",
+      "duration": "00:59:30",
+      "chapters": [
+        "00:20:00",
+        "00:19:45",
+        "00:19:45"
+      ]
+    },
+    {
+      "label": "Extended Cut",
+      "duration": "00:52:00",
+      "chapters": [
+        "00:26:00",
+        "00:26:00"
+      ]
+    },
+    {
+      "label": "Behind the Scenes",
+      "duration": "00:22:00",
+      "chapters": [
+        "00:11:00",
+        "00:11:00"
+      ]
+    },
+    {
+      "label": "Trailer Reel",
+      "duration": "00:05:00"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- expand the ambiguous disc fixture with borderline durations and chapter metadata so it better exercises the fallback heuristics
- mark the roadmap task complete now that the ambiguous fixture is present

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`

## References
- Task: [#P8-T3](TASKS.md#L73)

## Risks & Rollback
- Low risk: only updates test fixture data; revert commit if an unexpected interaction is observed.


------
https://chatgpt.com/codex/tasks/task_b_68e3cc61b8488321ad32ae4ed9801df0