### PR TITLE
#P8-T6 Add tests for naming sanitization options

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -73,7 +73,7 @@
 - [x] Add fixtures: ambiguous structure JSON (borderline durations) (file present) [#P8-T3]
 - [x] Tests: config precedence (defaults/config/CLI) (pytest passes) [#P8-T4]
 - [x] Tests: classification across all fixtures (pass; deterministic) [#P8-T5]
-- [ ] Tests: naming sanitization & lowercase options (pass) [#P8-T6]
+- [x] Tests: naming sanitization & lowercase options (pass) [#P8-T6]
 - [ ] Tests: dry-run planning prints expected actions (pass) [#P8-T7]
 - [ ] Tests: exit code mapping for common failures (pass) [#P8-T8]
 - [ ] Coverage gate ≥ 80% (report shows ≥80%) [#P8-T9]

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -39,6 +39,11 @@ def test_sanitize_component_applies_lowercase_when_requested() -> None:
     assert sanitized == "firefly_serenity"
 
 
+def test_sanitize_component_falls_back_when_separator_invalid() -> None:
+    sanitized = sanitize_component("Season • Finale", separator="•")
+    assert sanitized == "Season_Finale"
+
+
 def test_movie_output_path_uses_configured_directory(tmp_path: Path) -> None:
     title = TitleInfo(label="The Matrix", duration=timedelta(minutes=136))
     config = {
@@ -85,6 +90,23 @@ def test_series_output_path_defaults_without_naming_section(tmp_path: Path) -> N
     path = series_output_path("Strange Show", title, "s01e02", config)
 
     assert path == tmp_path / "Strange_Show" / "Strange_Show-s01e02_Episode_2.mp4"
+
+
+def test_series_output_path_applies_lowercase_and_sanitization(tmp_path: Path) -> None:
+    title = TitleInfo(label="Épisode Finale!", duration=timedelta(minutes=58))
+    config = {
+        "output_directory": tmp_path,
+        "naming": {"separator": "-", "lowercase": True},
+    }
+
+    path = series_output_path("Série Étrange?!", title, "s02e10", config)
+
+    expected = (
+        tmp_path
+        / "serie-etrange"
+        / "serie-etrange-s02e10_episode-finale.mp4"
+    )
+    assert path == expected
 
 
 def test_movie_output_path_adds_suffix_when_collision(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add regression coverage for `sanitize_component` when an invalid separator is provided
- verify series output paths honor the lowercase naming option while sanitizing accented titles
- mark TASKS.md entry #P8-T6 complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Task
- TASKS.md line 76 (#P8-T6)


------
https://chatgpt.com/codex/tasks/task_b_68e3d0878f8883219356642a2eba3791