### PR TITLE
Enforce coverage threshold in pytest addopts [#P8-T9]

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -76,7 +76,7 @@
 - [x] Tests: naming sanitization & lowercase options (pass) [#P8-T6]
 - [x] Tests: dry-run planning prints expected actions (pass) [#P8-T7]
 - [x] Tests: exit code mapping for common failures (pass) [#P8-T8]
-- [ ] Coverage gate ≥ 80% (report shows ≥80%) [#P8-T9]
+- [x] Coverage gate ≥ 80% (report shows ≥80%) [#P8-T9]
 
 ## Phase 9 – Packaging & Install
 - [ ] Finalize `pyproject.toml` metadata (name, version, classifiers) (builds sdist/wheel) [#P9-T1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,5 @@ line-length = 100
 select = ["E", "F"]
 
 [tool.pytest.ini_options]
-addopts = "-q"
+addopts = "-q --cov=src --cov-fail-under=80"
 pythonpath = ["src"]


### PR DESCRIPTION
## Summary
- configure pytest to always measure src coverage and fail under 80%
- mark the coverage gate task as complete in TASKS.md

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e3d4e9a0fc83218f1c7524ed72ee47