### PR TITLE
Finalize pyproject metadata (#P9-T1)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -79,7 +79,7 @@
 - [x] Coverage gate ≥ 80% (report shows ≥80%) [#P8-T9]
 
 ## Phase 9 – Packaging & Install
-- [ ] Finalize `pyproject.toml` metadata (name, version, classifiers) (builds sdist/wheel) [#P9-T1]
+- [x] Finalize `pyproject.toml` metadata (name, version, classifiers) (builds sdist/wheel) [#P9-T1]
 - [ ] Confirm `console_scripts` exposes `{ENTRYPOINT}` (invokes CLI after install) [#P9-T2]
 - [ ] Makefile: `install`, `lint`, `test`, `format` targets (targets run successfully) [#P9-T3]
 - [ ] Verify `pipx install -e .` and `pip install -e .` (both flows work) [#P9-T4]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,31 @@ build-backend = "setuptools.build_meta"
 name = "discripper"
 version = "0.1.0"
 description = "Utilities for inspecting and ripping optical discs."
+readme = "README.md"
 authors = [{ name = "discripper contributors" }]
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
+    "PyYAML>=6.0",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: End Users/Desktop",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Utilities",
+]
+license-files = ["LICENSE"]
+
+[project.optional-dependencies]
+dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
-    "PyYAML>=6.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add project metadata to `pyproject.toml`, including readme reference, license expression, classifiers, and development extras
- mark task #P9-T1 as complete in `TASKS.md`

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_b_68e3d90b16a48321812ca02615f7c810