### PR TITLE
#P9-T2 Confirm console script entry point

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -80,7 +80,7 @@
 
 ## Phase 9 – Packaging & Install
 - [x] Finalize `pyproject.toml` metadata (name, version, classifiers) (builds sdist/wheel) [#P9-T1]
-- [ ] Confirm `console_scripts` exposes `{ENTRYPOINT}` (invokes CLI after install) [#P9-T2]
+- [x] Confirm `console_scripts` exposes `{ENTRYPOINT}` (invokes CLI after install) [#P9-T2]
 - [ ] Makefile: `install`, `lint`, `test`, `format` targets (targets run successfully) [#P9-T3]
 - [ ] Verify `pipx install -e .` and `pip install -e .` (both flows work) [#P9-T4]
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,5 +1,6 @@
 """Smoke tests for the discripper package."""
 
+from importlib import metadata
 from pathlib import Path
 import sys
 
@@ -49,3 +50,19 @@ def test_pytest_pythonpath_includes_src() -> None:
 
     assert expected_src.exists()
     assert any(Path(path).resolve() == expected_src for path in map(Path, sys.path))
+
+
+def test_console_script_entry_point_registered() -> None:
+    """The console script entry point resolves to the CLI main function."""
+
+    entry_points = metadata.entry_points()
+    if hasattr(entry_points, "select"):
+        console_scripts = entry_points.select(group="console_scripts")
+    else:  # pragma: no cover - fallback for older importlib.metadata APIs
+        console_scripts = entry_points.get("console_scripts", [])
+
+    discripper_entry = next((ep for ep in console_scripts if ep.name == "discripper"), None)
+
+    assert discripper_entry is not None
+    assert discripper_entry.value == "discripper.cli:main"
+    assert discripper_entry.load() is cli.main


### PR DESCRIPTION
## Summary
- add an automated test that ensures the `discripper` console script resolves to the CLI main entry point
- mark the phase 9 packaging task as complete in `TASKS.md`

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`
- `discripper --help`


------
https://chatgpt.com/codex/tasks/task_b_68e3da2eb1d88321bb9de635d232efeb