### PR TITLE
#P9-T3 Add project Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: install lint test format
+
+install:
+	python -m pip install -e .
+
+lint:
+	ruff check .
+
+test:
+	pytest
+
+format:
+	ruff format .

--- a/TASKS.md
+++ b/TASKS.md
@@ -81,7 +81,7 @@
 ## Phase 9 – Packaging & Install
 - [x] Finalize `pyproject.toml` metadata (name, version, classifiers) (builds sdist/wheel) [#P9-T1]
 - [x] Confirm `console_scripts` exposes `{ENTRYPOINT}` (invokes CLI after install) [#P9-T2]
-- [ ] Makefile: `install`, `lint`, `test`, `format` targets (targets run successfully) [#P9-T3]
+- [x] Makefile: `install`, `lint`, `test`, `format` targets (targets run successfully) [#P9-T3]
 - [ ] Verify `pipx install -e .` and `pip install -e .` (both flows work) [#P9-T4]
 
 ## Phase 10 – Docs & Quickstart


### PR DESCRIPTION
## Summary
- add a Makefile that exposes install, lint, test, and format commands for contributors
- update TASKS.md to mark the Makefile task complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Links
- Task: [#P9-T3](TASKS.md)


------
https://chatgpt.com/codex/tasks/task_b_68e3dc187b808321a1f90b75e3599718