### PR TITLE
Implement #P9-T4: verify editable install flows

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -82,7 +82,7 @@
 - [x] Finalize `pyproject.toml` metadata (name, version, classifiers) (builds sdist/wheel) [#P9-T1]
 - [x] Confirm `console_scripts` exposes `{ENTRYPOINT}` (invokes CLI after install) [#P9-T2]
 - [x] Makefile: `install`, `lint`, `test`, `format` targets (targets run successfully) [#P9-T3]
-- [ ] Verify `pipx install -e .` and `pip install -e .` (both flows work) [#P9-T4]
+- [x] Verify `pipx install -e .` and `pip install -e .` (both flows work) [#P9-T4]
 
 ## Phase 10 – Docs & Quickstart
 - [ ] Root `README.md`: prerequisites (apt tools), install, usage (movie & series), dry-run (sections present) [#P10-T1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,6 @@ select = ["E", "F"]
 [tool.pytest.ini_options]
 addopts = "-q --cov=src --cov-fail-under=80"
 pythonpath = ["src"]
+markers = [
+    "slow: tests that exercise installation flows and may take longer to run",
+]

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -1,0 +1,68 @@
+"""Installation flow smoke tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _bin_dir(venv_dir: Path) -> Path:
+    """Return the bin/Scripts directory for a virtual environment."""
+
+    if os.name == "nt":  # pragma: no cover - Windows fallback
+        return venv_dir / "Scripts"
+    return venv_dir / "bin"
+
+
+def _run(cmd: list[str], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    """Execute a command and return the completed process."""
+
+    return subprocess.run(
+        cmd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.mark.slow
+def test_editable_install_via_pip_and_pipx(tmp_path: Path) -> None:
+    """Editable installs via pip and pipx expose the CLI entry point."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+
+    # pip install -e . in an isolated virtual environment
+    pip_venv = tmp_path / "pip-venv"
+    _run([sys.executable, "-m", "venv", str(pip_venv)])
+    pip_python = _bin_dir(pip_venv) / "python"
+    _run([str(pip_python), "-m", "pip", "install", "--upgrade", "pip"])
+    _run([str(pip_python), "-m", "pip", "install", "--editable", str(repo_root)])
+    pip_cli = _bin_dir(pip_venv) / "discripper"
+    pip_help = _run([str(pip_cli), "--help"])
+    assert pip_help.stdout.lower().startswith("usage:"), pip_help.stdout
+
+    # Ensure pipx is available, installing it locally if needed
+    if importlib.util.find_spec("pipx") is None:  # pragma: no cover - executed when pipx missing
+        _run([sys.executable, "-m", "pip", "install", "pipx"])
+
+    pipx_env = os.environ.copy()
+    pipx_env.update(
+        {
+            "PIPX_HOME": str(tmp_path / "pipx-home"),
+            "PIPX_BIN_DIR": str(tmp_path / "pipx-bin"),
+            "PIPX_SHARED_LIBS": str(tmp_path / "pipx-shared"),
+        }
+    )
+
+    pipx_command = [sys.executable, "-m", "pipx"]
+    _run(pipx_command + ["install", "--editable", str(repo_root)], env=pipx_env)
+    pipx_cli = Path(pipx_env["PIPX_BIN_DIR"]) / "discripper"
+    pipx_help = _run([str(pipx_cli), "--help"], env=pipx_env)
+    assert pipx_help.stdout.lower().startswith("usage:"), pipx_help.stdout
+    _run(pipx_command + ["uninstall", "discripper"], env=pipx_env)


### PR DESCRIPTION
## Summary
- add an integration test that exercises editable installs via both pip and pipx to ensure the CLI is exposed
- register a pytest `slow` marker so the new installation test runs without warnings
- mark TASKS entry [#P9-T4] complete

## Risks
- pipx integration test increases test runtime because it creates virtual environments on the fly

## Rollback
- revert commit `[test] Verify editable install flows`

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`
- `python -m pipx install --editable .`

## Task
- TASKS.md [#P9-T4]


------
https://chatgpt.com/codex/tasks/task_b_68e3dece2de08321a33be82e4e28b269