### PR TITLE
Add README quickstart sections [#P10-T1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,74 @@
 
 This repository is under active development. Core functionality such as configuration loading, device inspection, and ripping orchestration is tracked in `PRD.md` and `TASKS.md`.
 
-## Getting Started
+## Prerequisites
+
+`discripper` orchestrates several command-line tools that are typically available from Debian and Ubuntu package repositories. Install them before running the CLI:
+
+```bash
+sudo apt update
+sudo apt install ffmpeg lsdvd dvdbackup
+```
+
+* `ffmpeg` provides the ripping backend and includes `ffprobe` for fallback inspection.
+* `lsdvd` supplies the primary DVD title/duration metadata.
+* `dvdbackup` is used when available to clone discs prior to transcoding.
+
+Blu-ray discs that require decryption or CSS-protected DVDs may need additional third-party tooling; `discripper` does not perform circumvention.
+
+## Installation
+
+Install the project in editable mode while developing or testing:
 
 ```bash
 pip install -e .
 ```
 
-Once the CLI is implemented you will be able to run:
+Alternatively, install into an isolated environment with [`pipx`](https://pypa.github.io/pipx/):
 
 ```bash
-discripper --help
+pipx install --suffix=@dev \
+  --force --pip-args "--editable ." \
+  .
 ```
 
-Configuration will default to `~/.config/discripper.yaml` with CLI flags to override key settings. See `PRD.md` for the planned feature roadmap.
+After installation the `discripper` entry point is available on your `PATH`.
 
-## Ripping prerequisites
+Configuration defaults to `~/.config/discripper.yaml`, and CLI flags can override key settings. See `PRD.md` for the broader feature roadmap.
 
-The initial ripping path relies on [`ffmpeg`](https://ffmpeg.org/) being available on the system `PATH`.  The command reads
-directly from the supplied device node (for example `/dev/sr0`) and writes an MP4 file to the requested destination.  CSS or
-advanced Blu-ray decryption is **not** handled by `discripper`; external tools or system packages must be used when discs
-require additional decoding support.
+## Usage
+
+`discripper` inspects the provided optical device, classifies the contents, and plans rips into the configured output directory (default: `~/Videos`). The CLI exposes a consistent workflow for both movies and series.
+
+### Movie workflow
+
+Insert the disc and run:
+
+```bash
+discripper /dev/sr0
+```
+
+`discripper` discovers the primary title, logs a `TYPE=movie` classification event, and rips the main feature to `<output_directory>/<movieTitle>.mp4`.
+
+### Series workflow
+
+When the disc contains episodic content, the CLI automatically infers episode ordering and creates per-episode files. For example:
+
+```bash
+discripper /dev/sr0 --config ~/.config/discripper.yaml
+```
+
+The command emits structured logs such as `EVENT=CLASSIFIED TYPE=series EPISODES=6` and writes files following the pattern `<seriesName>/<seriesName>-s01eNN_<title>.mp4` inside the configured output directory.
+
+## Dry-run mode
+
+Use `--dry-run` when you want to verify the rip plan without performing any writes:
+
+```bash
+discripper /dev/sr0 --dry-run --verbose
+```
+
+The command prints the planned titles and destinations while leaving the filesystem untouched—ideal for validating configuration, naming rules, or tool availability.
 
 ## Exit codes
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -85,7 +85,7 @@
 - [x] Verify `pipx install -e .` and `pip install -e .` (both flows work) [#P9-T4]
 
 ## Phase 10 – Docs & Quickstart
-- [ ] Root `README.md`: prerequisites (apt tools), install, usage (movie & series), dry-run (sections present) [#P10-T1]
+- [x] Root `README.md`: prerequisites (apt tools), install, usage (movie & series), dry-run (sections present) [#P10-T1]
 - [ ] Document config schema and `{CONFIG_PATH}` override (examples provided) [#P10-T2]
 - [ ] Troubleshooting section: common errors & resolutions (page anchors added) [#P10-T3]
 - [ ] CLI `--help` examples included in docs (copy/paste verified) [#P10-T4]


### PR DESCRIPTION
## Summary
- document system prerequisites, installation methods, and runtime workflows in the root README
- describe movie, series, and dry-run usage flows and mark the corresponding roadmap task complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Risks
- Low: documentation-only update.

## Rollback
- Revert commit `[docs] Expand README quickstart sections`.

## Task
- TASKS.md (#P10-T1)


------
https://chatgpt.com/codex/tasks/task_b_68e3e1c2416c8321ab825cde46e5475e