### PR TITLE
[#P10-T3] Add troubleshooting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,35 @@ codes:
 Non-zero exit codes are accompanied by human-readable error messages on
 standard error so scripts can both log and react to failures.
 
+## Troubleshooting
+
+Jump directly to a common issue:
+
+- [Device not detected (`exit code 1`)](#device-not-detected-exit-code-1)
+- [Required tools missing from `PATH`](#required-tools-missing-from-path)
+- [Output directory cannot be created](#output-directory-cannot-be-created)
+
+### Device not detected (`exit code 1`)
+
+If the CLI exits with code 1, verify that the optical drive path is correct
+(`/dev/sr0` by default) and readable by your user. You may need to run
+`sudo usermod -a -G cdrom $USER` and log out/in so the process can access the
+device without elevated privileges.
+
+### Required tools missing from `PATH`
+
+`discripper` depends on utilities such as `ffmpeg`, `lsdvd`, and `dvdbackup`.
+If inspection fails with a "tool not found" error, re-run the install commands
+from [Prerequisites](#prerequisites) and ensure the binaries resolve via
+`which <tool>`.
+
+### Output directory cannot be created
+
+When the configured output directory is unwritable, the rip plan will abort
+before running external tools. Double-check the `output_directory` setting in
+your config file, ensure the parent folders exist, and confirm you have write
+permissions (e.g. `chmod u+w <path>`).
+
 ## Contributing
 
 1. Check the next open item in `TASKS.md`.

--- a/TASKS.md
+++ b/TASKS.md
@@ -87,7 +87,7 @@
 ## Phase 10 – Docs & Quickstart
 - [x] Root `README.md`: prerequisites (apt tools), install, usage (movie & series), dry-run (sections present) [#P10-T1]
 - [x] Document config schema and `{CONFIG_PATH}` override (examples provided) [#P10-T2]
-- [ ] Troubleshooting section: common errors & resolutions (page anchors added) [#P10-T3]
+- [x] Troubleshooting section: common errors & resolutions (page anchors added) [#P10-T3]
 - [ ] CLI `--help` examples included in docs (copy/paste verified) [#P10-T4]
 
 ## Phase 11 – Simulation / E2E Dry-Run


### PR DESCRIPTION
## Summary
- add a troubleshooting section to the README with anchors for quick navigation
- document resolutions for device detection, missing tools, and unwritable output directories
- mark roadmap task #P10-T3 as complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

------
https://chatgpt.com/codex/tasks/task_b_68e3e4059b3883218024d8a0937e29e3