### PR TITLE
#P10-T4 Add CLI help example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ settings.
 
 `discripper` inspects the provided optical device, classifies the contents, and plans rips into the configured output directory (default: `~/Videos`). The CLI exposes a consistent workflow for both movies and series.
 
+### CLI help
+
+Inspect the built-in help to review all supported flags and arguments:
+
+```console
+$ discripper --help
+usage: discripper [-h] [--config CONFIG_PATH] [--verbose] [--dry-run] [device]
+
+discripper command-line interface
+
+positional arguments:
+  device                Path to the optical media device (default: /dev/sr0).
+
+options:
+  -h, --help            show this help message and exit
+  --config CONFIG_PATH  Path to the configuration file to use.
+  --verbose             Enable verbose (DEBUG) logging output.
+  --dry-run             Perform a dry run without executing side effects.
+```
+
 ### Movie workflow
 
 Insert the disc and run:

--- a/TASKS.md
+++ b/TASKS.md
@@ -88,7 +88,7 @@
 - [x] Root `README.md`: prerequisites (apt tools), install, usage (movie & series), dry-run (sections present) [#P10-T1]
 - [x] Document config schema and `{CONFIG_PATH}` override (examples provided) [#P10-T2]
 - [x] Troubleshooting section: common errors & resolutions (page anchors added) [#P10-T3]
-- [ ] CLI `--help` examples included in docs (copy/paste verified) [#P10-T4]
+- [x] CLI `--help` examples included in docs (copy/paste verified) [#P10-T4]
 
 ## Phase 11 – Simulation / E2E Dry-Run
 - [ ] Hidden flag `--simulate FIXTURE.json` drives full pipeline without hardware (flag works) [#P11-T1]


### PR DESCRIPTION
## Summary
- add the `discripper --help` output to the README for easy reference
- mark the documentation task complete in `TASKS.md`

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

Task: TASKS.md [#P10-T4]

------
https://chatgpt.com/codex/tasks/task_b_68e3e556922483219d833b0597522490