### PR TITLE
Add simulation sample fixtures [#P11-T2]

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -92,7 +92,7 @@
 
 ## Phase 11 – Simulation / E2E Dry-Run
 - [x] Hidden flag `--simulate FIXTURE.json` drives full pipeline without hardware (flag works) [#P11-T1]
-- [ ] Provide two sample simulation JSONs (movie, series) (files included) [#P11-T2]
+- [x] Provide two sample simulation JSONs (movie, series) (files included) [#P11-T2]
 - [ ] `scripts/demo.sh` shows planning & dry-run with simulate (script runs clean) [#P11-T3]
 
 ## Phase 12 – Optional / Deferred Features

--- a/samples/simulated_movie.json
+++ b/samples/simulated_movie.json
@@ -1,0 +1,15 @@
+{
+  "label": "Simulation: Feature Film",
+  "titles": [
+    {
+      "label": "Main Feature",
+      "duration": 6780,
+      "chapters": [1800, 1800, 1980, 1200]
+    },
+    {
+      "label": "Deleted Scenes",
+      "duration": 900,
+      "chapters": [300, 300, 300]
+    }
+  ]
+}

--- a/samples/simulated_series.json
+++ b/samples/simulated_series.json
@@ -1,0 +1,25 @@
+{
+  "label": "Simulation: Limited Series",
+  "titles": [
+    {
+      "label": "Episode 1",
+      "duration": 2700,
+      "chapters": [900, 900, 900]
+    },
+    {
+      "label": "Episode 2",
+      "duration": 2760,
+      "chapters": [900, 870, 990]
+    },
+    {
+      "label": "Episode 3",
+      "duration": 2640,
+      "chapters": [840, 900, 900]
+    },
+    {
+      "label": "Episode 4",
+      "duration": 2820,
+      "chapters": [900, 960, 960]
+    }
+  ]
+}

--- a/tests/test_fake_inspector.py
+++ b/tests/test_fake_inspector.py
@@ -92,3 +92,17 @@ def test_inspect_from_fixture_accepts_custom_directory(tmp_path: Path) -> None:
         timedelta(minutes=3, seconds=20),
         timedelta(minutes=3, seconds=20),
     )
+
+
+def test_simulation_samples_are_available() -> None:
+    samples_dir = Path(__file__).resolve().parents[1] / "samples"
+
+    movie_disc = inspect_from_fixture("simulated_movie", fixture_dir=samples_dir)
+    assert movie_disc.label == "Simulation: Feature Film"
+    assert len(movie_disc.titles) == 2
+    assert movie_disc.titles[0].label == "Main Feature"
+
+    series_disc = inspect_from_fixture("simulated_series", fixture_dir=samples_dir)
+    assert series_disc.label == "Simulation: Limited Series"
+    assert len(series_disc.titles) == 4
+    assert series_disc.titles[0].label == "Episode 1"


### PR DESCRIPTION
## Summary
- add packaged simulation fixtures for movie and series scenarios
- exercise the new fixtures in the fake inspector tests
- mark the simulation fixtures roadmap task complete

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_68e3e80e04ec832189390e2fa3f9f8aa