### PR TITLE
#P11-T3 Add simulation demo script

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -93,7 +93,7 @@
 ## Phase 11 – Simulation / E2E Dry-Run
 - [x] Hidden flag `--simulate FIXTURE.json` drives full pipeline without hardware (flag works) [#P11-T1]
 - [x] Provide two sample simulation JSONs (movie, series) (files included) [#P11-T2]
-- [ ] `scripts/demo.sh` shows planning & dry-run with simulate (script runs clean) [#P11-T3]
+- [x] `scripts/demo.sh` shows planning & dry-run with simulate (script runs clean) [#P11-T3]
 
 ## Phase 12 – Optional / Deferred Features
 - [ ] Post-rip HandBrake hook if `compression=true` (command assembled; disabled by default) [#P12-T1]

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SAMPLES_DIR="$ROOT_DIR/samples"
+
+DEMO_TEMP_DIR=""
+cleanup() {
+  if [[ -n "$DEMO_TEMP_DIR" && -d "$DEMO_TEMP_DIR" ]]; then
+    rm -rf "$DEMO_TEMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  DEMO_TEMP_DIR="$(mktemp -d)"
+  cat <<'STUB' >"$DEMO_TEMP_DIR/ffmpeg"
+#!/usr/bin/env bash
+echo "[demo] ffmpeg stub invoked with: $@" >&2
+exit 0
+STUB
+  chmod +x "$DEMO_TEMP_DIR/ffmpeg"
+  export PATH="$DEMO_TEMP_DIR:$PATH"
+fi
+
+if command -v discripper >/dev/null 2>&1; then
+  CLI=(discripper)
+else
+  export PYTHONPATH="$ROOT_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
+  CLI=(python -m discripper.cli)
+fi
+
+run_demo() {
+  local label="$1"
+  local fixture="$2"
+  echo "==> $label"
+  "${CLI[@]}" --simulate "$fixture" --dry-run
+  echo
+}
+
+run_demo "Movie disc simulation" "$SAMPLES_DIR/simulated_movie.json"
+run_demo "Series disc simulation" "$SAMPLES_DIR/simulated_series.json"

--- a/tests/test_demo_script.py
+++ b/tests/test_demo_script.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_demo_script_runs_successfully() -> None:
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "demo.sh"
+    assert script_path.exists(), "demo.sh must exist for the demo task"
+
+    env = os.environ.copy()
+
+    result = subprocess.run(
+        ["bash", str(script_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    if result.returncode != 0:
+        message = (
+            "demo.sh failed with exit code "
+            f"{result.returncode}:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+        raise AssertionError(message)
+
+    assert "[dry-run]" in result.stdout, "demo script should display dry-run output"


### PR DESCRIPTION
## Summary
- add `scripts/demo.sh` to run the CLI in simulation mode for the bundled movie and series fixtures
- make the demo resilient by stubbing `ffmpeg` when missing and falling back to `python -m discripper.cli`
- cover the script with a pytest and mark the roadmap task complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Risks
- Low; the change adds a demo helper script and an accompanying test only.

## Rollback
- Revert the commit `[feat] Add simulation demo script`.

## Task
- [#P11-T3](TASKS.md#L96)


------
https://chatgpt.com/codex/tasks/task_b_68e3e98fdc1883218413521aebe9a304