### PR TITLE
[#P12-T1] Log HandBrake compression plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ logging:
   level: INFO
 ```
 
+When `compression` is set to `true` the CLI logs a ready-to-run
+`HandBrakeCLI` command for each ripped file. The hook does not execute the
+command automatically; it simply assembles a safe default that you can copy
+once the rip completes. Leave the option at its default of `false` to skip
+generating the compression plans.
+
 CLI flags such as `--dry-run` and `--verbose` take precedence over values in the
 configuration file, allowing quick one-off overrides without editing disk
 settings.

--- a/TASKS.md
+++ b/TASKS.md
@@ -96,7 +96,7 @@
 - [x] `scripts/demo.sh` shows planning & dry-run with simulate (script runs clean) [#P11-T3]
 
 ## Phase 12 – Optional / Deferred Features
-- [ ] Post-rip HandBrake hook if `compression=true` (command assembled; disabled by default) [#P12-T1]
+- [x] Post-rip HandBrake hook if `compression=true` (command assembled; disabled by default) [#P12-T1]
 - [ ] Configurable episode title inference strategy (pluggable; documented) [#P12-T2]
 - [ ] Metadata lookup (TheTVDB/TMDB) placeholder interface (non-blocking stub) [#P12-T3]
 


### PR DESCRIPTION
## Summary
- add HandBrake compression plan helpers in the CLI and log them when compression is enabled
- extend CLI tests to validate compression logging for executed and dry-run plans
- document how the compression flag surfaces the HandBrake command and mark the roadmap task complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

------
https://chatgpt.com/codex/tasks/task_b_68e3ead9d5e883219b6eac5c98633626