### PR TITLE
[#P12-T3] Add metadata lookup placeholder interface

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -98,7 +98,7 @@
 ## Phase 12 – Optional / Deferred Features
 - [x] Post-rip HandBrake hook if `compression=true` (command assembled; disabled by default) [#P12-T1]
 - [x] Configurable episode title inference strategy (pluggable; documented) [#P12-T2]
-- [ ] Metadata lookup (TheTVDB/TMDB) placeholder interface (non-blocking stub) [#P12-T3]
+- [x] Metadata lookup (TheTVDB/TMDB) placeholder interface (non-blocking stub) [#P12-T3]
 
 ## Phase 13 – Final QA & Acceptance
 - [ ] `scripts/acceptance.sh` runs fixtures end-to-end (exit codes & plans verified) [#P13-T1]

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -23,6 +23,14 @@ from .discovery import (
 from .dvd import inspect_dvd
 from .fake import inspect_from_fixture
 from .ffprobe import inspect_with_ffprobe
+from .metadata import (
+    DEFAULT_METADATA_PROVIDER,
+    DiscMetadata,
+    EpisodeMetadata,
+    MetadataLookupResult,
+    MetadataProvider,
+    NullMetadataProvider,
+)
 from .naming import movie_output_path, sanitize_component, series_output_path
 from .rip import RipExecutionError, RipPlan, rip_disc, rip_title, run_rip_plan
 
@@ -43,6 +51,12 @@ __all__ = [
     "inspect_blu_ray",
     "inspect_with_ffprobe",
     "inspect_from_fixture",
+    "EpisodeMetadata",
+    "DiscMetadata",
+    "MetadataLookupResult",
+    "MetadataProvider",
+    "NullMetadataProvider",
+    "DEFAULT_METADATA_PROVIDER",
     "sanitize_component",
     "movie_output_path",
     "series_output_path",

--- a/src/discripper/core/metadata.py
+++ b/src/discripper/core/metadata.py
@@ -1,0 +1,85 @@
+"""Placeholder metadata lookup interfaces for future integrations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from . import DiscInfo
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodeMetadata:
+    """Describes metadata for a single episode on a disc."""
+
+    title: str | None = None
+    overview: str | None = None
+    season: int | None = None
+    number: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DiscMetadata:
+    """Collection of metadata describing an entire disc."""
+
+    title: str | None = None
+    overview: str | None = None
+    episodes: tuple[EpisodeMetadata, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial tuple conversion
+        object.__setattr__(self, "episodes", tuple(self.episodes))
+
+
+@dataclass(frozen=True, slots=True)
+class MetadataLookupResult:
+    """Result produced by a :class:`MetadataProvider`."""
+
+    provider: str
+    metadata: DiscMetadata | None
+    message: str | None = None
+
+    @property
+    def found(self) -> bool:
+        """Return :data:`True` when metadata is available."""
+
+        return self.metadata is not None
+
+
+@runtime_checkable
+class MetadataProvider(Protocol):
+    """Protocol describing metadata providers such as TheTVDB or TMDB."""
+
+    name: str
+
+    def lookup_disc(self, disc: "DiscInfo") -> MetadataLookupResult:
+        """Return metadata for *disc* or a placeholder result."""
+
+
+@dataclass(frozen=True, slots=True)
+class NullMetadataProvider:
+    """Fallback provider used until external integrations are implemented."""
+
+    name: str = "none"
+
+    def lookup_disc(self, disc: "DiscInfo") -> MetadataLookupResult:  # pragma: no cover - thin
+        return MetadataLookupResult(
+            provider=self.name,
+            metadata=None,
+            message=(
+                "Metadata lookup is not yet implemented. "
+                "This placeholder avoids blocking rip workflows."
+            ),
+        )
+
+
+DEFAULT_METADATA_PROVIDER = NullMetadataProvider()
+
+__all__ = [
+    "EpisodeMetadata",
+    "DiscMetadata",
+    "MetadataLookupResult",
+    "MetadataProvider",
+    "NullMetadataProvider",
+    "DEFAULT_METADATA_PROVIDER",
+]

--- a/tests/test_metadata_stub.py
+++ b/tests/test_metadata_stub.py
@@ -1,0 +1,36 @@
+"""Tests for the metadata placeholder interfaces."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from discripper.core import (
+    DEFAULT_METADATA_PROVIDER,
+    DiscInfo,
+    DiscMetadata,
+    EpisodeMetadata,
+    MetadataLookupResult,
+    NullMetadataProvider,
+    TitleInfo,
+)
+
+
+def test_disc_metadata_normalizes_episode_iterables() -> None:
+    episode = EpisodeMetadata(title="Pilot")
+    metadata = DiscMetadata(episodes=[episode])
+
+    assert isinstance(metadata.episodes, tuple)
+    assert metadata.episodes == (episode,)
+
+
+def test_null_metadata_provider_returns_placeholder_message() -> None:
+    disc = DiscInfo(label="Sample Disc", titles=(TitleInfo("Title 1", timedelta(minutes=90)),))
+
+    provider: NullMetadataProvider = DEFAULT_METADATA_PROVIDER
+    result = provider.lookup_disc(disc)
+
+    assert isinstance(result, MetadataLookupResult)
+    assert result.provider == "none"
+    assert result.metadata is None
+    assert result.message and "not yet implemented" in result.message
+    assert not result.found


### PR DESCRIPTION
## Summary
- add placeholder metadata data classes and provider protocol with a non-blocking default implementation
- re-export metadata interfaces through the core package and add regression tests covering normalization and placeholder behavior

## Testing
- pip install -e .
- pip install -e .[dev]
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e3f092c46c8321a44173d0b36d3c8b