### PR TITLE
Add acceptance script for simulation fixtures [#P13-T1]

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -101,7 +101,7 @@
 - [x] Metadata lookup (TheTVDB/TMDB) placeholder interface (non-blocking stub) [#P12-T3]
 
 ## Phase 13 – Final QA & Acceptance
-- [ ] `scripts/acceptance.sh` runs fixtures end-to-end (exit codes & plans verified) [#P13-T1]
+- [x] `scripts/acceptance.sh` runs fixtures end-to-end (exit codes & plans verified) [#P13-T1]
 - [ ] Verify PRD acceptance criteria satisfied (checklist compiled) [#P13-T2]
 - [ ] Verify directory/naming conventions match PRD (examples produced) [#P13-T3]
 - [ ] Verify config defaults & overrides (table in docs updated) [#P13-T4]

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SAMPLES_DIR="$ROOT_DIR/samples"
+
+ACCEPTANCE_TEMP_DIR=""
+cleanup() {
+  if [[ -n "$ACCEPTANCE_TEMP_DIR" && -d "$ACCEPTANCE_TEMP_DIR" ]]; then
+    rm -rf "$ACCEPTANCE_TEMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+if command -v discripper >/dev/null 2>&1; then
+  CLI=(discripper)
+else
+  export PYTHONPATH="$ROOT_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
+  CLI=(python -m discripper.cli)
+fi
+
+if ! command -v dvdbackup >/dev/null 2>&1 && ! command -v ffmpeg >/dev/null 2>&1; then
+  ACCEPTANCE_TEMP_DIR="$(mktemp -d)"
+  cat <<'STUB' >"$ACCEPTANCE_TEMP_DIR/ffmpeg"
+#!/usr/bin/env bash
+echo "[acceptance] ffmpeg stub invoked with: $@" >&2
+exit 0
+STUB
+  chmod +x "$ACCEPTANCE_TEMP_DIR/ffmpeg"
+  export PATH="$ACCEPTANCE_TEMP_DIR:$PATH"
+fi
+
+abspath() {
+  local path="$1"
+  if [[ "$path" == /* ]]; then
+    printf '%s\n' "$path"
+    return
+  fi
+
+  local dir
+  dir="$(cd "$(dirname "$path")" && pwd)"
+  printf '%s/%s\n' "$dir" "$(basename "$path")"
+}
+
+run_case() {
+  local label="$1"
+  local fixture="$2"
+  local expected_type="$3"
+  local expected_plans="$4"
+
+  local fixture_path
+  fixture_path="$(abspath "$SAMPLES_DIR/$fixture")"
+
+  echo "==> $label"
+  local output
+  if ! output=$("${CLI[@]}" --simulate "$fixture_path" 2>&1); then
+    echo "$output"
+    echo "[acceptance] Scenario '$label' failed" >&2
+    return 1
+  fi
+
+  echo "$output"
+
+  if ! grep -q "EVENT=CLASSIFIED TYPE=$expected_type" <<<"$output"; then
+    echo "[acceptance] Expected classification type '$expected_type' not found for $label" >&2
+    return 1
+  fi
+
+  if grep -q '^Error:' <<<"$output"; then
+    echo "[acceptance] Encountered error output for $label" >&2
+    return 1
+  fi
+
+  local plan_count
+  plan_count=$(grep -c '\[dry-run\] Would execute:' <<<"$output" || true)
+  if [[ "$plan_count" -ne "$expected_plans" ]]; then
+    echo "[acceptance] Expected $expected_plans rip plans but saw $plan_count for $label" >&2
+    return 1
+  fi
+}
+
+run_case "Movie disc simulation" "simulated_movie.json" "movie" 1
+run_case "Series disc simulation" "simulated_series.json" "series" 4
+
+echo "All acceptance scenarios passed."

--- a/tests/test_acceptance_script.py
+++ b/tests/test_acceptance_script.py
@@ -1,0 +1,36 @@
+"""Tests for the acceptance helper script."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_acceptance_script_runs() -> None:
+    """Running the acceptance script succeeds and reports success."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "acceptance.sh"
+
+    assert script.exists(), "acceptance script must exist"
+
+    env = os.environ.copy()
+    env.setdefault(
+        "PYTHONPATH",
+        f"{repo_root / 'src'}{os.pathsep}{env.get('PYTHONPATH', '')}".rstrip(os.pathsep),
+    )
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=repo_root,
+        capture_output=True,
+        check=True,
+        text=True,
+        env=env,
+    )
+
+    combined_output = f"{result.stdout}{result.stderr}".strip()
+
+    assert "All acceptance scenarios passed." in combined_output
+    assert combined_output.count("[dry-run] Would execute:") == 5


### PR DESCRIPTION
## Summary
- add an acceptance helper script that runs the movie and series simulation fixtures and validates their rip plans
- exercise the new script from pytest to ensure the acceptance flow continues to pass
- mark the Phase 13 acceptance checklist item as complete in TASKS.md

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80
- scripts/acceptance.sh


------
https://chatgpt.com/codex/tasks/task_b_68e3f240152c8321aae340c03d83bf15