### PR TITLE
#P13-T3 Document verified naming examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,32 @@ discripper /dev/sr0 --dry-run --verbose
 
 The command prints the planned titles and destinations while leaving the filesystem untouched—ideal for validating configuration, naming rules, or tool availability.
 
+## Output naming examples
+
+Run the simulation fixtures to see the sanitised filenames that `discripper` produces while respecting the PRD conventions:
+
+```bash
+bash scripts/demo.sh
+```
+
+The default configuration targets `~/Videos`, so a movie disc resolves to:
+
+```
+~/Videos/Main_Feature.mp4
+```
+
+Series discs follow the `<series>/<series>-s01eNN_<title>.mp4` structure:
+
+```
+~/Videos/Simulation_Limited_Series/
+├── Simulation_Limited_Series-s01e01_Episode_3.mp4
+├── Simulation_Limited_Series-s01e02_Episode_1.mp4
+├── Simulation_Limited_Series-s01e03_Episode_2.mp4
+└── Simulation_Limited_Series-s01e04_Episode_4.mp4
+```
+
+These examples come directly from the `samples/simulated_*.json` fixtures and are asserted by `tests/test_samples_naming.py`, keeping the documentation in lockstep with the implementation.
+
 ## Exit codes
 
 `discripper` communicates high-level failure modes via conventional process exit

--- a/TASKS.md
+++ b/TASKS.md
@@ -103,7 +103,7 @@
 ## Phase 13 – Final QA & Acceptance
 - [x] `scripts/acceptance.sh` runs fixtures end-to-end (exit codes & plans verified) [#P13-T1]
 - [x] Verify PRD acceptance criteria satisfied (checklist compiled) [#P13-T2]
-- [ ] Verify directory/naming conventions match PRD (examples produced) [#P13-T3]
+- [x] Verify directory/naming conventions match PRD (examples produced) [#P13-T3]
 - [ ] Verify config defaults & overrides (table in docs updated) [#P13-T4]
 
 ## Phase 14 – Validation Against PRD

--- a/tests/test_samples_naming.py
+++ b/tests/test_samples_naming.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from discripper.config import DEFAULT_CONFIG
+from discripper.core.classifier import classify_disc, thresholds_from_config
+from discripper.core.fake import inspect_from_fixture
+from discripper.core.naming import movie_output_path, series_output_path
+
+
+def _simulation_fixture(name: str) -> Path:
+    return Path(__file__).resolve().parents[1] / "samples" / f"{name}.json"
+
+
+def test_simulated_movie_output_matches_prd_pattern(tmp_path: Path) -> None:
+    config = DEFAULT_CONFIG.copy()
+    output_dir = tmp_path / "Videos"
+    config["output_directory"] = str(output_dir)
+
+    disc = inspect_from_fixture(_simulation_fixture("simulated_movie"))
+    classification = classify_disc(disc, thresholds=thresholds_from_config(config))
+
+    assert classification.disc_type == "movie"
+
+    movie_plan = movie_output_path(classification.episodes[0], config)
+    assert movie_plan == output_dir / "Main_Feature.mp4"
+
+
+def test_simulated_series_output_matches_prd_pattern(tmp_path: Path) -> None:
+    config = DEFAULT_CONFIG.copy()
+    output_dir = tmp_path / "Videos"
+    config["output_directory"] = str(output_dir)
+
+    disc = inspect_from_fixture(_simulation_fixture("simulated_series"))
+    classification = classify_disc(disc, thresholds=thresholds_from_config(config))
+
+    assert classification.disc_type == "series"
+    assert classification.episode_codes is not None
+
+    destinations = [
+        series_output_path(disc.label, title, code, config)
+        for title, code in zip(classification.episodes, classification.episode_codes)
+    ]
+
+    expected_dir = output_dir / "Simulation_Limited_Series"
+    assert destinations == [
+        expected_dir / "Simulation_Limited_Series-s01e01_Episode_3.mp4",
+        expected_dir / "Simulation_Limited_Series-s01e02_Episode_1.mp4",
+        expected_dir / "Simulation_Limited_Series-s01e03_Episode_2.mp4",
+        expected_dir / "Simulation_Limited_Series-s01e04_Episode_4.mp4",
+    ]


### PR DESCRIPTION
## Summary
- add README guidance that demonstrates the PRD-compliant movie and series output layout using the simulation fixtures
- introduce fixture-based tests that assert the generated filenames for the bundled movie and series samples
- mark the Phase 13 naming verification checklist item as complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e40b7849b8832181bb2964254f37b1