### PR TITLE
#P13-T4 Document config defaults table

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,28 @@ series discs. Use the default `label` strategy to keep the source title labels, 
 `episode-number` for generic `Episode 01` style names, or point to a custom callable using
 the `module:callable` notation to plug in project-specific logic.
 
+### Defaults & overrides
+
+`discripper` resolves configuration in three tiers: built-in defaults,
+values from the active YAML file, and finally CLI flags. Use the table below
+to verify each setting's default and the available override surface.
+
+| Setting | Default | Config key | CLI override | Notes |
+| --- | --- | --- | --- | --- |
+| Configuration file path | `~/.config/discripper.yaml` | — | `--config` | Expands `~`; accepts relative paths. |
+| `output_directory` | `~/Videos` | `output_directory` | — | Created automatically. |
+| `compression` | `false` | `compression` | — | Emits HandBrake commands. |
+| `dry_run` | `false` | `dry_run` | `--dry-run`, `--simulate` | CLI flags override config. |
+| `classification.movie_main_title_minutes` | `60` | `classification.movie_main_title_minutes` | — | Minutes for main title. |
+| `classification.movie_total_runtime_minutes` | `180` | `classification.movie_total_runtime_minutes` | — | Max runtime for movies. |
+| `classification.series_min_duration_minutes` | `20` | `classification.series_min_duration_minutes` | — | Episode minimum length. |
+| `classification.series_max_duration_minutes` | `60` | `classification.series_max_duration_minutes` | — | Episode maximum length. |
+| `classification.series_gap_limit` | `0.2` | `classification.series_gap_limit` | — | Allowed duration variance. |
+| `naming.separator` | `_` | `naming.separator` | — | Filename segment joiner. |
+| `naming.lowercase` | `false` | `naming.lowercase` | — | Lowercases destination paths. |
+| `naming.episode_title_strategy` | `label` | `naming.episode_title_strategy` | — | Selects episode naming strategy. |
+| `logging.level` | `INFO` | `logging.level` | `--verbose` | Flag forces `DEBUG` logging. |
+
 ### Example configuration
 
 ```yaml

--- a/TASKS.md
+++ b/TASKS.md
@@ -104,7 +104,7 @@
 - [x] `scripts/acceptance.sh` runs fixtures end-to-end (exit codes & plans verified) [#P13-T1]
 - [x] Verify PRD acceptance criteria satisfied (checklist compiled) [#P13-T2]
 - [x] Verify directory/naming conventions match PRD (examples produced) [#P13-T3]
-- [ ] Verify config defaults & overrides (table in docs updated) [#P13-T4]
+- [x] Verify config defaults & overrides (table in docs updated) [#P13-T4]
 
 ## Phase 14 – Validation Against PRD
 - [ ] Produce validation report mapping implementation → PRD sections (✅/❌ per item) [#P14-T1]

--- a/tests/test_docs_defaults.py
+++ b/tests/test_docs_defaults.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+
+from discripper import config
+
+
+def _flatten(mapping: Mapping[str, object], prefix: str = ""):
+    for key, value in mapping.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, Mapping):
+            yield from _flatten(value, path)
+        else:
+            yield path, value
+
+
+def _format_default(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        home = str(Path.home())
+        if home and value.startswith(home):
+            remainder = value[len(home) :].lstrip("/")
+            return f"~/{remainder}" if remainder else "~"
+        return value
+    return str(value)
+
+
+def test_readme_defaults_table_matches_defaults() -> None:
+    readme = Path("README.md").read_text(encoding="utf-8")
+    parts = readme.split("### Defaults & overrides", maxsplit=1)
+    assert len(parts) == 2, "Defaults & overrides section missing"
+
+    section = parts[1]
+    if "###" in section:
+        section = section.split("###", maxsplit=1)[0]
+
+    table_block = re.findall(r"^\|.*$", section, flags=re.MULTILINE)
+    assert table_block, "Defaults & overrides table is missing"
+
+    lines = [line.strip() for line in table_block]
+    table_defaults: dict[str, str] = {}
+    for line in lines:
+        if not line.startswith("|") or line.startswith("| ---"):
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        setting_cell, default_cell = cells[0], cells[1]
+        setting = setting_cell.strip("`")
+        if setting in {"Setting", ""}:
+            continue
+        table_defaults[setting] = default_cell.strip("`")
+
+    expected_config_path = str(config.CONFIG_PATH)
+    assert (
+        table_defaults.get("Configuration file path") == expected_config_path
+    ), "Configuration file path row mismatch"
+
+    for path, value in _flatten(config.DEFAULT_CONFIG):
+        formatted = _format_default(value)
+        assert path in table_defaults, f"Missing defaults row for {path}"
+        assert (
+            table_defaults[path] == formatted
+        ), f"Default mismatch for {path}: expected {formatted!r}"


### PR DESCRIPTION
## Summary
- add a README table that documents each configuration default alongside its override mechanism
- add a regression test to keep the documentation aligned with `DEFAULT_CONFIG`
- mark #P13-T4 as complete in `TASKS.md`

## Testing
- `pip install -e .`
- `pip install -e .[dev]`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_68e40ebb92448321a0dfb15fa0330b2f