### PR TITLE
#P14-T2 Document validation follow-ups

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -108,5 +108,8 @@
 
 ## Phase 14 – Validation Against PRD
 - [x] Produce validation report mapping implementation → PRD sections (✅/❌ per item) [#P14-T1]
-- [ ] List gaps & propose minimal follow-ups (new tasks enumerated) [#P14-T2]
+- [x] List gaps & propose minimal follow-ups (new tasks enumerated) [#P14-T2]
 - [ ] Sign-off: Reviewer + Auditor notes recorded in `.codex/reviews/` & `.codex/audit/` (files present) [#P14-T3]
+
+## Phase 15 – Follow-up Improvements
+- [ ] Implement optional log file support per PRD Section 8 (configurable path + CLI flag) [#P15-T1]

--- a/VALIDATION_REPORT.md
+++ b/VALIDATION_REPORT.md
@@ -84,3 +84,9 @@ This report validates the current implementation against the product requirement
 | Configurable output directory respected | ✅ | `tests/test_config.py::test_config_precedence` covers overrides. |
 | Errors handled with clear messaging | ✅ | `tests/test_cli.py::test_cli_missing_device_returns_exit_code_one` verifies messaging and exit codes. |
 
+## 10. Gap Analysis & Follow-up Tasks
+
+| Gap | Impact | Proposed Follow-up |
+| --- | --- | --- |
+| Optional log file support from PRD Section 8 is not implemented; logging only goes to stdout/stderr. | Users cannot persist structured logs for auditing or long-running rips without external tools. | Add configuration/CLI support for specifying an optional log file destination and update logging initialisation accordingly (`TASKS.md` `[#P15-T1]`). |
+


### PR DESCRIPTION
## Summary
- add a gap analysis section to the validation report and call out the missing optional log file support
- register a follow-up task in TASKS.md for implementing configurable log file output and mark #P14-T2 complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e4143634188321a040bd2e42bd64c8