### PR TITLE
fix: handle lsdvd payloads without disc wrapper

### DIFF
--- a/src/discripper/core/dvd.py
+++ b/src/discripper/core/dvd.py
@@ -45,9 +45,13 @@ def _parse_lsdvd_output(output: str) -> Mapping[str, object]:
 
     if key == "lsdvd":
         disc_payload = payload.get("disc")
-        if not isinstance(disc_payload, Mapping):
-            raise ValueError("Parsed lsdvd wrapper does not contain disc mapping")
-        return disc_payload
+        if isinstance(disc_payload, Mapping):
+            return disc_payload
+
+        if any(key in payload for key in ("track", "title", "track_count")):
+            return payload
+
+        raise ValueError("Parsed lsdvd wrapper does not contain disc mapping")
 
     return payload
 


### PR DESCRIPTION
## Summary
- allow the DVD parser to fall back to wrapper metadata when the nested disc mapping is absent
- add coverage for lsdvd outputs that omit the disc field

## Testing
- pytest -o addopts='' -p no:cov

------
https://chatgpt.com/codex/tasks/task_b_68e42d351fec8321a143049d87fcc8e1