### PR TITLE
Add roadmap tasks for menu OCR enrichment

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -113,3 +113,11 @@
 
 ## Phase 15 – Follow-up Improvements
 - [x] Implement optional log file support per PRD Section 8 (configurable path + CLI flag) [#P15-T1]
+- [ ] Extend metadata config for optional menu OCR enrichment (schema, defaults, tests) [#P15-T2]
+- [ ] Build core menu OCR module with frame sampling, OCR backend integration, and structured logs (module returns labels) [#P15-T3]
+- [ ] Implement per-disc OCR label cache with modes and persistence under XDG cache (cache hit/miss verified) [#P15-T4]
+- [ ] Enrich DiscInfo/TitleInfo structures to carry OCR-derived labels alongside existing metadata (dataclasses updated) [#P15-T5]
+- [ ] Integrate OCR enrichment into CLI flow with flags, time budget, failure fallbacks, and sidecar outputs (end-to-end path tested) [#P15-T6]
+- [ ] Update naming helpers to leverage OCR labels above confidence threshold with fallback behavior (naming tests updated) [#P15-T7]
+- [ ] Add unit tests for OCR config, pipeline, caching, logging, and label mapping behaviors (pytest suite passing) [#P15-T8]
+- [ ] Document OCR enrichment usage, configuration, and cache/log interpretation in README and docs (docs updated) [#P15-T9]


### PR DESCRIPTION
## Summary
- extend Phase 15 roadmap with new tasks covering menu OCR enrichment workstreams
- document configuration, core OCR module, caching, integration, testing, and documentation follow-ups

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68e44bf1c43c8321b2dfdd4aac1291cd