### PR TITLE
Revert menu OCR configuration defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,6 @@ in YAML terms—strings may include `~` for home-directory expansion.
 | `naming.lowercase` | boolean | When true, lowercase all generated paths. |
 | `naming.episode_title_strategy` | string | Episode title inference strategy (`label`, `episode-number`, or `module:callable`). |
 | `logging.level` | string or integer | Logging level (e.g. `INFO`, `DEBUG`, or `20`). |
-| `metadata.menu_ocr.enabled` | boolean | Toggle OCR enrichment for disc menus. |
-| `metadata.menu_ocr.backend` | string | OCR backend to use (e.g. `tesseract`). |
-| `metadata.menu_ocr.language` | string | Primary OCR language code. |
-| `metadata.menu_ocr.confidence_threshold` | number | Minimum confidence required to adopt OCR labels. |
-| `metadata.menu_ocr.frame_sample_interval` | number | Seconds between sampled menu frames during OCR. |
-| `metadata.menu_ocr.max_regions` | number | Maximum text regions to evaluate per menu capture. |
 
 The `naming.episode_title_strategy` option controls how episode names are inferred for
 series discs. Use the default `label` strategy to keep the source title labels, switch to
@@ -118,12 +112,6 @@ to verify each setting's default and the available override surface.
 | `naming.episode_title_strategy` | `label` | `naming.episode_title_strategy` | — | Selects episode naming strategy. |
 | `logging.level` | `INFO` | `logging.level` | `--verbose` | Flag forces `DEBUG` logging. |
 | `logging.file` | None | `logging.file` | `--log-file` | Optional log file path; leave unset to disable. |
-| `metadata.menu_ocr.enabled` | `false` | `metadata.menu_ocr.enabled` | — | Leave disabled to skip OCR enrichment. |
-| `metadata.menu_ocr.backend` | `tesseract` | `metadata.menu_ocr.backend` | — | Backend identifier used by OCR module. |
-| `metadata.menu_ocr.language` | `eng` | `metadata.menu_ocr.language` | — | ISO language code passed to OCR backend. |
-| `metadata.menu_ocr.confidence_threshold` | `0.6` | `metadata.menu_ocr.confidence_threshold` | — | Minimum confidence before using OCR results. |
-| `metadata.menu_ocr.frame_sample_interval` | `5` | `metadata.menu_ocr.frame_sample_interval` | — | Seconds between sampled menu frames. |
-| `metadata.menu_ocr.max_regions` | `5` | `metadata.menu_ocr.max_regions` | — | Text regions inspected per sampled frame. |
 
 ### Example configuration
 
@@ -145,14 +133,6 @@ naming:
 logging:
   level: INFO
   file: null
-metadata:
-  menu_ocr:
-    enabled: false
-    backend: tesseract
-    language: eng
-    confidence_threshold: 0.6
-    frame_sample_interval: 5
-    max_regions: 5
 ```
 
 When `compression` is set to `true` the CLI logs a ready-to-run

--- a/TASKS.md
+++ b/TASKS.md
@@ -113,7 +113,7 @@
 
 ## Phase 15 – Follow-up Improvements
 - [x] Implement optional log file support per PRD Section 8 (configurable path + CLI flag) [#P15-T1]
-- [x] Extend metadata config for optional menu OCR enrichment (schema, defaults, tests) [#P15-T2]
+- [ ] Extend metadata config for optional menu OCR enrichment (schema, defaults, tests) [#P15-T2]
 - [ ] Build core menu OCR module with frame sampling, OCR backend integration, and structured logs (module returns labels) [#P15-T3]
 - [ ] Implement per-disc OCR label cache with modes and persistence under XDG cache (cache hit/miss verified) [#P15-T4]
 - [ ] Enrich DiscInfo/TitleInfo structures to carry OCR-derived labels alongside existing metadata (dataclasses updated) [#P15-T5]

--- a/src/discripper/config.py
+++ b/src/discripper/config.py
@@ -30,16 +30,6 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "level": "INFO",
         "file": None,
     },
-    "metadata": {
-        "menu_ocr": {
-            "enabled": False,
-            "backend": "tesseract",
-            "language": "eng",
-            "confidence_threshold": 0.6,
-            "frame_sample_interval": 5,
-            "max_regions": 5,
-        },
-    },
 }
 
 CONFIG_SCHEMA: dict[str, Any] = {
@@ -61,16 +51,6 @@ CONFIG_SCHEMA: dict[str, Any] = {
     "logging": {
         "level": (str, int),
         "file": (str, type(None)),
-    },
-    "metadata": {
-        "menu_ocr": {
-            "enabled": bool,
-            "backend": str,
-            "language": str,
-            "confidence_threshold": (int, float),
-            "frame_sample_interval": (int, float),
-            "max_regions": (int, float),
-        },
     },
 }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,30 +28,6 @@ def test_load_config_overrides_defaults(tmp_path: Path) -> None:
     assert loaded["naming"]["separator"] == config.DEFAULT_CONFIG["naming"]["separator"]
 
 
-def test_load_config_overrides_menu_ocr_settings(tmp_path: Path) -> None:
-    config_file = tmp_path / "config.yaml"
-    config_file.write_text(
-        "metadata:\n"
-        "  menu_ocr:\n"
-        "    enabled: true\n"
-        "    backend: easyocr\n"
-        "    language: spa\n"
-        "    confidence_threshold: 0.9\n"
-        "    frame_sample_interval: 2\n"
-        "    max_regions: 3\n"
-    )
-
-    loaded = config.load_config(config_file)
-
-    menu_ocr = loaded["metadata"]["menu_ocr"]
-    assert menu_ocr["enabled"] is True
-    assert menu_ocr["backend"] == "easyocr"
-    assert menu_ocr["language"] == "spa"
-    assert menu_ocr["confidence_threshold"] == pytest.approx(0.9)
-    assert menu_ocr["frame_sample_interval"] == 2
-    assert menu_ocr["max_regions"] == 3
-
-
 def test_load_config_respects_logging_file(tmp_path: Path) -> None:
     config_file = tmp_path / "config.yaml"
     config_file.write_text(
@@ -86,12 +62,4 @@ def test_load_config_validates_nested_schema(tmp_path: Path) -> None:
     config_file.write_text("naming: lowercase\n")
 
     with pytest.raises(ValueError, match="naming"):
-        config.load_config(config_file)
-
-
-def test_load_config_validates_menu_ocr_types(tmp_path: Path) -> None:
-    config_file = tmp_path / "config.yaml"
-    config_file.write_text("metadata:\n  menu_ocr: true\n")
-
-    with pytest.raises(ValueError, match="menu_ocr"):
         config.load_config(config_file)


### PR DESCRIPTION
## Summary
- revert the metadata.menu_ocr defaults and schema entries
- remove README documentation and tests for the OCR configuration
- restore the Phase 15 task checklist entry to its unchecked state

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_68e45d90a55c8321a4c4643431feaa11