### PR TITLE
Add Phase X tasks for title-aware ripping enhancements

### DIFF
--- a/.codex/issues/phase-x-title-aware.md
+++ b/.codex/issues/phase-x-title-aware.md
@@ -1,0 +1,38 @@
+---
+title: "Tracking Issue: Phase X – Title-aware Ripping & Metadata JSON"
+labels:
+  - phase:title-aware
+  - component:cli
+  - component:ripper
+  - type:feature
+  - area:metadata
+---
+
+## Summary
+Coordinate the implementation of Phase X tasks from `TASKS.md` to introduce a title-aware ripping flow with deterministic naming and structured metadata export.
+
+## Task Links
+- [ ] `TASKS.md` → Phase X task [#PX-T1]
+- [ ] `TASKS.md` → Phase X task [#PX-T2]
+- [ ] `TASKS.md` → Phase X task [#PX-T3]
+- [ ] `TASKS.md` → Phase X task [#PX-T4]
+- [ ] `TASKS.md` → Phase X task [#PX-T5]
+- [ ] `TASKS.md` → Phase X task [#PX-T6]
+- [ ] `TASKS.md` → Phase X task [#PX-T7]
+- [ ] `TASKS.md` → Phase X task [#PX-T8]
+
+## Comments
+[START] Phase X – Title-aware Ripping & Metadata JSON
+[TEAM-COMM] Summary of new Phase X tasks
+task: TASKS.md#phase-x--title-aware-ripping--metadata-json
+role: Task Master
+status: START
+links: n/a
+notes: Phase X ready for CODER pickup
+
+Highlights for CODER:
+- `#PX-T1`: CLI accepts `--title/-t`, falls back to disc label when omitted, and logs the resolved title.
+- `#PX-T2`: Title slug drives deterministic output structure `{slug}/{slug}_track{NN}.{ext}` honoring `{CONFIG_PATH}` overrides.
+- `#PX-T3`: Write `{slug}/metadata.json` capturing disc + track metadata; schema to be documented in `docs/metadata-schema.md`.
+- `#PX-T6`: Tests cover CLI flag, slug rules, metadata writer (including missing field tolerances).
+- `#PX-T7`: Docs require README updates plus full schema documentation in `docs/metadata-schema.md`.

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -1,0 +1,5 @@
+# Metadata Schema (TODO)
+
+> TODO: Populate this document with the stable JSON schema for `metadata.json` once implemented in Phase X (#PX-T3, #PX-T7).
+
+This stub exists to anchor documentation updates required by the upcoming title-aware ripping work. Update with field definitions, data types, and an example payload when the metadata export is implemented.


### PR DESCRIPTION
## Summary
- add Phase X roadmap items to `TASKS.md` covering title flag, naming, metadata, docs, and changelog work
- create `docs/metadata-schema.md` stub for the forthcoming metadata export schema
- open a tracking issue with labels for coordinating Phase X work

## Testing
- not run (docs-only)


------
https://chatgpt.com/codex/tasks/task_b_68e47e2fa708832199ee6eba7f3a8d05