### PR TITLE
[#PX-T1] Add CLI title override flag

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -116,7 +116,7 @@
 
 ## Phase X – Title-aware Ripping & Metadata JSON
 
-- [ ] Add CLI flag for human title `--title` / `-t` [#PX-T1]
+- [x] Add CLI flag for human title `--title` / `-t` [#PX-T1]
   - **Description:** Extend `{ENTRYPOINT}` CLI to accept an optional `--title` (string). If omitted, attempt a sensible fallback (e.g., disc label or existing auto-detect) without failing the run.
   - **Acceptance Criteria:**
     - Running `discripper --help` documents `--title/-t`.


### PR DESCRIPTION
## Summary
- add a --title/-t CLI option that records manual overrides in the configuration and logs the resolved title
- ensure the CLI selects a fallback title when none is provided and expose the chosen value to downstream planning
- extend CLI tests to cover the new flag, configuration precedence, propagation, and fallback messaging

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e481cd1188832189eef7ab918824ed