### PR TITLE
Implement slug-based output naming (#PX-T2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,26 +204,30 @@ The command prints the planned titles and destinations while leaving the filesys
 
 ## Output naming examples
 
-Run the simulation fixtures to see the sanitised filenames that `discripper` produces while respecting the PRD conventions:
+Run the simulation fixtures to see the slugged filenames that `discripper`
+produces while respecting the PRD conventions:
 
 ```bash
 bash scripts/demo.sh
 ```
 
-The default configuration targets `~/Videos`, so a movie disc resolves to:
+The default configuration targets `~/Videos`, so a movie disc resolves to the
+disc-title slug with numbered tracks:
 
 ```
-~/Videos/Main_Feature.mp4
+~/Videos/simulation-feature-film/
+└── simulation-feature-film_track01.mp4
 ```
 
-Series discs follow the `<series>/<series>-s01eNN_<title>.mp4` structure:
+Series discs follow the `{slug}/{slug}_trackNN.mp4` structure, where the slug
+comes from the provided or detected disc title:
 
 ```
-~/Videos/Simulation_Limited_Series/
-├── Simulation_Limited_Series-s01e01_Episode_3.mp4
-├── Simulation_Limited_Series-s01e02_Episode_1.mp4
-├── Simulation_Limited_Series-s01e03_Episode_2.mp4
-└── Simulation_Limited_Series-s01e04_Episode_4.mp4
+~/Videos/simulation-limited-series/
+├── simulation-limited-series_track01.mp4
+├── simulation-limited-series_track02.mp4
+├── simulation-limited-series_track03.mp4
+└── simulation-limited-series_track04.mp4
 ```
 
 These examples come directly from the `samples/simulated_*.json` fixtures and are asserted by `tests/test_samples_naming.py`, keeping the documentation in lockstep with the implementation.

--- a/TASKS.md
+++ b/TASKS.md
@@ -123,7 +123,7 @@
     - `discripper -t "The Matrix"` is accepted and propagated to the ripping workflow.
     - If no title is provided, process continues with fallback and prints which title is used.
 
-- [ ] Apply title to output naming scheme [#PX-T2]
+- [x] Apply title to output naming scheme [#PX-T2]
   - **Description:** Use the provided (or resolved) title to replace generic filenames (e.g., `title_01`) with a deterministic, slugified scheme. Default pattern:
     - `{slug}/{slug}_track{NN}.{ext}`
     - Where `{slug}` is derived from the title; `{NN}` is 2-digit track index; `{ext}` follows current container (e.g., mkv/mp4).

--- a/src/discripper/cli.py
+++ b/src/discripper/cli.py
@@ -75,19 +75,25 @@ def _destination_factory(
     disc: DiscInfo,
     classification: ClassificationResult,
     config: Mapping[str, Any],
-) -> Callable[[TitleInfo, str | None], Path]:
+) -> Callable[[TitleInfo, str | None, int], Path]:
     """Return a destination factory compatible with :func:`rip_disc`."""
 
-    def factory(title: TitleInfo, episode_code: str | None) -> Path:
+    def factory(title: TitleInfo, episode_code: str | None, track_index: int) -> Path:
         if classification.disc_type == "movie":
-            return movie_output_path(title, config)
+            return movie_output_path(title, config, track_index=track_index)
 
         if not episode_code:
             raise RuntimeError(
                 "Series classification requires episode codes for destination planning"
             )
 
-        return series_output_path(disc.label, title, episode_code, config)
+        return series_output_path(
+            disc.label,
+            title,
+            episode_code,
+            config,
+            track_index=track_index,
+        )
 
     return factory
 

--- a/src/discripper/core/rip.py
+++ b/src/discripper/core/rip.py
@@ -553,7 +553,7 @@ def run_rip_plan(
 def rip_disc(
     device: str | Path,
     classification: "ClassificationResult",
-    destination_factory: Callable[["TitleInfo", str | None], str | Path],
+    destination_factory: Callable[["TitleInfo", str | None, int], str | Path],
     *,
     dry_run: bool = False,
     which: Callable[[str], Optional[str]] = default_which,
@@ -575,8 +575,8 @@ def rip_disc(
         episode_codes = tuple(None for _ in episodes)
 
     plans = []
-    for title, code in zip(episodes, episode_codes):
-        destination = destination_factory(title, code)
+    for index, (title, code) in enumerate(zip(episodes, episode_codes), start=1):
+        destination = destination_factory(title, code, index)
         plans.append(
             rip_title(
                 device,

--- a/tests/test_rip.py
+++ b/tests/test_rip.py
@@ -142,9 +142,10 @@ def test_rip_disc_movie_invokes_destination_factory(
     classification = ClassificationResult("movie", (sample_title,))
     destinations: list[Path] = []
 
-    def destination_factory(title: TitleInfo, code: str | None) -> Path:
+    def destination_factory(title: TitleInfo, code: str | None, index: int) -> Path:
         assert code is None
         assert title is sample_title
+        assert index == 1
         path = tmp_path / f"{title.label}.mp4"
         destinations.append(path)
         return path
@@ -168,9 +169,9 @@ def test_rip_disc_series_uses_episode_codes(tmp_path: Path) -> None:
         "series", (title_one, title_two), ("s01e01", "s01e02")
     )
 
-    def destination_factory(title: TitleInfo, code: str | None) -> Path:
+    def destination_factory(title: TitleInfo, code: str | None, index: int) -> Path:
         assert code is not None
-        return tmp_path / f"{code}_{title.label}.mp4"
+        return tmp_path / f"{index:02d}_{code}_{title.label}.mp4"
 
     plans = rip_disc(
         "/dev/sr0",
@@ -182,8 +183,8 @@ def test_rip_disc_series_uses_episode_codes(tmp_path: Path) -> None:
 
     assert len(plans) == 2
     assert [plan.destination.name for plan in plans] == [
-        "s01e01_Pilot.mp4",
-        "s01e02_Episode Two.mp4",
+        "01_s01e01_Pilot.mp4",
+        "02_s01e02_Episode Two.mp4",
     ]
     assert all(plan.will_execute is False for plan in plans)
 

--- a/tests/test_samples_naming.py
+++ b/tests/test_samples_naming.py
@@ -22,8 +22,11 @@ def test_simulated_movie_output_matches_prd_pattern(tmp_path: Path) -> None:
 
     assert classification.disc_type == "movie"
 
+    config["title"] = disc.label
+
     movie_plan = movie_output_path(classification.episodes[0], config)
-    assert movie_plan == output_dir / "Main_Feature.mp4"
+    expected = output_dir / "simulation-feature-film" / "simulation-feature-film_track01.mp4"
+    assert movie_plan == expected
 
 
 def test_simulated_series_output_matches_prd_pattern(tmp_path: Path) -> None:
@@ -37,15 +40,26 @@ def test_simulated_series_output_matches_prd_pattern(tmp_path: Path) -> None:
     assert classification.disc_type == "series"
     assert classification.episode_codes is not None
 
+    config["title"] = disc.label
+
     destinations = [
-        series_output_path(disc.label, title, code, config)
-        for title, code in zip(classification.episodes, classification.episode_codes)
+        series_output_path(
+            disc.label,
+            title,
+            code,
+            config,
+            track_index=index,
+        )
+        for index, (title, code) in enumerate(
+            zip(classification.episodes, classification.episode_codes),
+            start=1,
+        )
     ]
 
-    expected_dir = output_dir / "Simulation_Limited_Series"
+    expected_dir = output_dir / "simulation-limited-series"
     assert destinations == [
-        expected_dir / "Simulation_Limited_Series-s01e01_Episode_3.mp4",
-        expected_dir / "Simulation_Limited_Series-s01e02_Episode_1.mp4",
-        expected_dir / "Simulation_Limited_Series-s01e03_Episode_2.mp4",
-        expected_dir / "Simulation_Limited_Series-s01e04_Episode_4.mp4",
+        expected_dir / "simulation-limited-series_track01.mp4",
+        expected_dir / "simulation-limited-series_track02.mp4",
+        expected_dir / "simulation-limited-series_track03.mp4",
+        expected_dir / "simulation-limited-series_track04.mp4",
     ]


### PR DESCRIPTION
## Summary
- derive a deterministic slug from the selected disc title and reuse it for movie and series destinations
- thread track indices through the CLI destination factory and rip orchestrator so outputs follow the `{slug}_trackNN` scheme
- refresh unit tests, sample naming expectations, and README examples to cover the new title-driven layout

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_68e484d1156c8321a477007d3f23182c