### PR TITLE
#PX-T3 Add metadata JSON export

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -132,7 +132,7 @@
     - Slug rules documented (spaces → `-`, lowercased, non-alnum removed except `-` and `_`).
     - Configurable root output directory respected (from `{CONFIG_PATH}` if applicable).
 
-- [ ] Extract disc & stream metadata to JSON [#PX-T3]
+- [x] Extract disc & stream metadata to JSON [#PX-T3]
   - **Description:** After rip, generate `metadata.json` adjacent to outputs capturing:
     - Disc-level: volume label, disc ID/identifier (if available), rip timestamp, tool versions.
     - Title/track list with: index, duration, container, video/audio codec(s), bitrate(s), resolution, framerate, chapter count/map, file size (if post-rip), and any language/subtitle tracks.

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -1,5 +1,107 @@
-# Metadata Schema (TODO)
+# Metadata Schema
 
-> TODO: Populate this document with the stable JSON schema for `metadata.json` once implemented in Phase X (#PX-T3, #PX-T7).
+The ripping pipeline writes a `metadata.json` document alongside ripped files in the
+slugged output directory (for example: `~/Videos/the-matrix/metadata.json`). The
+document captures disc-level details, the selected classification, the resolved
+title, tool versions, and a per-track breakdown of the media that was produced.
 
-This stub exists to anchor documentation updates required by the upcoming title-aware ripping work. Update with field definitions, data types, and an example payload when the metadata export is implemented.
+## Top-level structure
+
+`metadata.json` is a JSON object with the following fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `generated_at` | string (ISO 8601) | Timestamp when the metadata document was created (UTC). |
+| `disc` | object | Disc metadata containing `label` (string) and `id` (nullable string, currently `null`). |
+| `classification` | object | Summary of classification results. Contains `type` (`"movie"` or `"series"`) and `episode_count` (integer). |
+| `title` | string or null | Effective title used for naming (CLI flag, config, or fallback). |
+| `output_root` | string or null | Absolute path to the directory containing rip artifacts. |
+| `tools` | object | Map of tool name → version string (or `null` if unavailable). Includes ripping backends and `ffprobe` when present. |
+| `tracks` | array | List of per-track objects (see below). |
+
+## Track entries
+
+Each element in `tracks` describes the media planned and produced for a single
+title. Track objects contain the following keys:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `index` | integer | 1-based position of the track in the ripping plan. |
+| `title` | string | Human-readable label from inspection. |
+| `episode_code` | string or null | Episode identifier (e.g., `"s01e01"`) when classification yielded series metadata. |
+| `planned_duration_seconds` | number | Duration reported during inspection (float seconds). |
+| `chapters` | object | Contains `count` (integer) and `map` (array of `{ "index": int, "duration_seconds": number }` entries describing chapter lengths). |
+| `output` | object | Describes the rip artifact with keys: `path` (string), `container` (string or null), `exists` (boolean), `size_bytes` (integer or null). |
+| `format` | object | Container summary from `ffprobe` (`container`, `duration_seconds`, `bit_rate`). Values may be `null` when unavailable. |
+| `streams` | array | Stream entries from `ffprobe`. Each entry includes `type` (`video`, `audio`, `subtitle`, etc.), `index`, `codec`, `codec_long`, `bit_rate`, `language`, and additional type-specific fields (`width`, `height`, `frame_rate`, `pixel_format` for video; `channels`, `channel_layout`, `sample_rate` for audio; `title` for subtitles). |
+
+When `ffprobe` is unavailable or a file is missing, the corresponding `format`
+fields and `streams` array are populated with `null`/empty values while keeping
+the schema stable.
+
+## Example
+
+```json
+{
+  "generated_at": "2024-01-01T00:00:00+00:00",
+  "disc": {"label": "Sample Disc", "id": null},
+  "classification": {"type": "movie", "episode_count": 1},
+  "title": "The Matrix",
+  "output_root": "/home/user/Videos/the-matrix",
+  "tools": {
+    "ffmpeg": "ffmpeg version n6.0",
+    "ffprobe": "ffprobe version n6.0"
+  },
+  "tracks": [
+    {
+      "index": 1,
+      "title": "Main Feature",
+      "episode_code": null,
+      "planned_duration_seconds": 5400.5,
+      "chapters": {
+        "count": 12,
+        "map": [
+          {"index": 1, "duration_seconds": 450.0},
+          {"index": 2, "duration_seconds": 460.0}
+        ]
+      },
+      "output": {
+        "path": "/home/user/Videos/the-matrix/the-matrix_track01.mp4",
+        "container": "mp4",
+        "exists": true,
+        "size_bytes": 123456789
+      },
+      "format": {
+        "container": "mov,mp4,m4a,3gp,3g2,mj2",
+        "duration_seconds": 5400.5,
+        "bit_rate": 1500000
+      },
+      "streams": [
+        {
+          "type": "video",
+          "index": 0,
+          "codec": "h264",
+          "codec_long": "H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10",
+          "bit_rate": 1200000,
+          "language": "eng",
+          "width": 1920,
+          "height": 1080,
+          "frame_rate": 29.97,
+          "pixel_format": "yuv420p"
+        },
+        {
+          "type": "audio",
+          "index": 1,
+          "codec": "aac",
+          "codec_long": "AAC (Advanced Audio Coding)",
+          "bit_rate": 192000,
+          "language": "eng",
+          "channels": 2,
+          "channel_layout": "stereo",
+          "sample_rate": 48000
+        }
+      ]
+    }
+  ]
+}
+```

--- a/src/discripper/core/metadata_json.py
+++ b/src/discripper/core/metadata_json.py
@@ -1,0 +1,329 @@
+"""Utilities for exporting rip metadata to structured JSON documents."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from fractions import Fraction
+from itertools import zip_longest
+from pathlib import Path
+from shutil import which as default_which
+from subprocess import CalledProcessError, CompletedProcess, run as subprocess_run
+from typing import TYPE_CHECKING, Callable, Mapping, Sequence
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checking only
+    from . import ClassificationResult, DiscInfo
+    from .rip import RipPlan
+
+
+Runner = Callable[..., CompletedProcess[str]]
+
+__all__ = [
+    "build_metadata_document",
+    "write_metadata_document",
+]
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _to_int(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            try:
+                return int(float(value))
+            except ValueError:
+                return None
+    return None
+
+
+def _to_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _frame_rate(stream: Mapping[str, object]) -> float | None:
+    rate = stream.get("avg_frame_rate") or stream.get("r_frame_rate")
+    if isinstance(rate, (int, float)):
+        return float(rate)
+    if isinstance(rate, str):
+        if "/" in rate:
+            try:
+                return float(Fraction(rate))
+            except (ZeroDivisionError, ValueError):
+                return None
+        try:
+            return float(rate)
+        except ValueError:
+            return None
+    return None
+
+
+def _language_from_stream(stream: Mapping[str, object]) -> str | None:
+    tags = stream.get("tags")
+    if isinstance(tags, Mapping):
+        language = tags.get("language")
+        if isinstance(language, str) and language.strip():
+            return language.strip()
+    return None
+
+
+def _parse_streams(streams: Sequence[object] | None) -> list[dict[str, object]]:
+    parsed: list[dict[str, object]] = []
+    if not isinstance(streams, Sequence):
+        return parsed
+
+    for raw_stream in streams:
+        if not isinstance(raw_stream, Mapping):
+            continue
+
+        codec_type = raw_stream.get("codec_type")
+        if not isinstance(codec_type, str):
+            continue
+
+        stream_info: dict[str, object] = {
+            "type": codec_type,
+            "index": raw_stream.get("index"),
+            "codec": raw_stream.get("codec_name"),
+            "codec_long": raw_stream.get("codec_long_name"),
+            "bit_rate": _to_int(raw_stream.get("bit_rate")),
+            "language": _language_from_stream(raw_stream),
+        }
+
+        if codec_type == "video":
+            stream_info.update(
+                {
+                    "width": raw_stream.get("width"),
+                    "height": raw_stream.get("height"),
+                    "frame_rate": _frame_rate(raw_stream),
+                    "pixel_format": raw_stream.get("pix_fmt"),
+                }
+            )
+        elif codec_type == "audio":
+            stream_info.update(
+                {
+                    "channels": raw_stream.get("channels"),
+                    "channel_layout": raw_stream.get("channel_layout"),
+                    "sample_rate": _to_int(raw_stream.get("sample_rate")),
+                }
+            )
+        elif codec_type == "subtitle":
+            subtitle_tags = raw_stream.get("tags")
+            if isinstance(subtitle_tags, Mapping):
+                stream_info["title"] = subtitle_tags.get("title")
+
+        parsed.append(stream_info)
+
+    return parsed
+
+
+def _chapter_map(plan: "RipPlan") -> list[dict[str, object]]:
+    chapters: list[dict[str, object]] = []
+    for index, chapter_duration in enumerate(plan.title.chapters, start=1):
+        chapters.append(
+            {
+                "index": index,
+                "duration_seconds": chapter_duration.total_seconds(),
+            }
+        )
+    return chapters
+
+
+def _ffprobe_payload(
+    ffprobe_path: str,
+    media_path: Path,
+    *,
+    runner: Runner,
+) -> Mapping[str, object] | None:
+    try:
+        result = runner(
+            (
+                ffprobe_path,
+                "-v",
+                "error",
+                "-print_format",
+                "json",
+                "-show_streams",
+                "-show_format",
+                "-show_chapters",
+                str(media_path),
+            ),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, CalledProcessError, OSError):
+        return None
+
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+
+    if isinstance(payload, Mapping):
+        return payload
+    return None
+
+
+def _format_info(payload: Mapping[str, object] | None) -> dict[str, object]:
+    if not isinstance(payload, Mapping):
+        return {}
+
+    format_section = payload.get("format")
+    if not isinstance(format_section, Mapping):
+        return {}
+
+    return {
+        "container": format_section.get("format_name"),
+        "duration_seconds": _to_float(format_section.get("duration")),
+        "bit_rate": _to_int(format_section.get("bit_rate")),
+    }
+
+
+def _collect_tool_versions(
+    plans: Sequence["RipPlan"],
+    *,
+    runner: Runner,
+    ffprobe_path: str | None,
+) -> dict[str, str | None]:
+    tools: set[str] = set()
+    for plan in plans:
+        if plan.command:
+            tools.add(plan.command[0])
+    if ffprobe_path:
+        tools.add(Path(ffprobe_path).name)
+
+    versions: dict[str, str | None] = {}
+    for tool in sorted(tools):
+        versions[tool] = _probe_version(tool, runner=runner)
+    return versions
+
+
+def _probe_version(tool: str, *, runner: Runner) -> str | None:
+    for flag in ("--version", "-version"):
+        try:
+            result = runner(
+                (tool, flag),
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (FileNotFoundError, CalledProcessError, OSError):
+            continue
+
+        text = (result.stdout or result.stderr or "").strip()
+        if text:
+            return text.splitlines()[0]
+
+    return None
+
+
+def _metadata_output_path(plans: Sequence["RipPlan"]) -> Path | None:
+    for plan in plans:
+        if plan.will_execute:
+            return plan.destination.parent
+    return None
+
+
+def build_metadata_document(
+    disc: "DiscInfo",
+    classification: "ClassificationResult",
+    plans: Sequence["RipPlan"],
+    *,
+    config: Mapping[str, object],
+    which: Callable[[str], str | None] = default_which,
+    ffprobe_runner: Runner = subprocess_run,
+    version_runner: Runner = subprocess_run,
+    now: Callable[[], datetime] = _now_utc,
+) -> dict[str, object]:
+    ffprobe_path = which("ffprobe")
+    metadata_root = _metadata_output_path(plans)
+
+    tracks: list[dict[str, object]] = []
+    episode_codes: Sequence[str | None] = ()
+    if classification.episode_codes:
+        episode_codes = classification.episode_codes
+    else:
+        episode_codes = tuple(None for _ in classification.episodes)
+
+    for index, pair in enumerate(zip_longest(plans, episode_codes, fillvalue=None), start=1):
+        plan = pair[0]
+        if plan is None:
+            continue
+        episode_code = pair[1]
+        output_path = plan.destination
+        exists = output_path.exists()
+        size_bytes: int | None = None
+        if exists:
+            try:
+                size_bytes = output_path.stat().st_size
+            except OSError:
+                size_bytes = None
+
+        ffprobe_payload = None
+        if ffprobe_path and exists:
+            ffprobe_payload = _ffprobe_payload(ffprobe_path, output_path, runner=ffprobe_runner)
+
+        track_document: dict[str, object] = {
+            "index": index,
+            "title": plan.title.label,
+            "episode_code": episode_code,
+            "planned_duration_seconds": plan.title.duration.total_seconds(),
+            "chapters": {
+                "count": len(plan.title.chapters),
+                "map": _chapter_map(plan),
+            },
+            "output": {
+                "path": str(output_path),
+                "container": output_path.suffix[1:] if output_path.suffix else None,
+                "exists": exists,
+                "size_bytes": size_bytes,
+            },
+            "format": _format_info(ffprobe_payload),
+            "streams": _parse_streams(
+                ffprobe_payload.get("streams") if isinstance(ffprobe_payload, Mapping) else None
+            ),
+        }
+
+        tracks.append(track_document)
+
+    document: dict[str, object] = {
+        "generated_at": now().isoformat(),
+        "disc": {
+            "label": disc.label,
+            "id": None,
+        },
+        "classification": {
+            "type": classification.disc_type,
+            "episode_count": len(classification.episodes),
+        },
+        "title": config.get("title"),
+        "output_root": str(metadata_root) if metadata_root else None,
+        "tools": _collect_tool_versions(plans, runner=version_runner, ffprobe_path=ffprobe_path),
+        "tracks": tracks,
+    }
+
+    return document
+
+
+def write_metadata_document(document: Mapping[str, object], directory: Path) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "metadata.json"
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(document, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    return path
+

--- a/tests/test_metadata_json.py
+++ b/tests/test_metadata_json.py
@@ -1,0 +1,142 @@
+"""Tests for metadata JSON export helpers."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from subprocess import CompletedProcess
+
+from discripper.core import ClassificationResult, DiscInfo, RipPlan, TitleInfo
+from discripper.core.metadata_json import build_metadata_document, write_metadata_document
+
+
+def _fake_version_runner(command: tuple[str, ...], **_kwargs) -> CompletedProcess[str]:
+    tool = command[0]
+    return CompletedProcess(command, 0, stdout=f"{tool} version test\n", stderr="")
+
+
+def test_build_metadata_document_includes_streams(tmp_path: Path) -> None:
+    title = TitleInfo(label="Main Feature", duration=timedelta(minutes=95))
+    disc = DiscInfo(label="Sample Disc", titles=(title,))
+    classification = ClassificationResult("movie", (title,))
+
+    destination = tmp_path / "the-matrix" / "the-matrix_track01.mp4"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"example")
+
+    plan = RipPlan(
+        device="/dev/sr0",
+        title=title,
+        destination=destination,
+        command=("ffmpeg", "-i", "/dev/sr0", str(destination)),
+        will_execute=True,
+    )
+
+    ffprobe_payload = {
+        "format": {
+            "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
+            "duration": "5400.5",
+            "bit_rate": "1500000",
+        },
+        "streams": [
+            {
+                "index": 0,
+                "codec_type": "video",
+                "codec_name": "h264",
+                "bit_rate": "1200000",
+                "width": 1920,
+                "height": 1080,
+                "avg_frame_rate": "30000/1001",
+                "pix_fmt": "yuv420p",
+                "tags": {"language": "eng"},
+            },
+            {
+                "index": 1,
+                "codec_type": "audio",
+                "codec_name": "aac",
+                "bit_rate": "192000",
+                "channels": 2,
+                "channel_layout": "stereo",
+                "sample_rate": "48000",
+                "tags": {"language": "eng"},
+            },
+        ],
+    }
+
+    def fake_ffprobe_runner(command: tuple[str, ...], **_kwargs) -> CompletedProcess[str]:
+        assert command[0] == "ffprobe"
+        return CompletedProcess(command, 0, stdout=json.dumps(ffprobe_payload), stderr="")
+
+    document = build_metadata_document(
+        disc,
+        classification,
+        (plan,),
+        config={"title": "The Matrix"},
+        which=lambda name: name,
+        ffprobe_runner=fake_ffprobe_runner,
+        version_runner=_fake_version_runner,
+        now=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert document["disc"] == {"label": "Sample Disc", "id": None}
+    assert document["title"] == "The Matrix"
+    assert document["classification"]["type"] == "movie"
+    assert document["tracks"][0]["output"]["path"] == str(destination)
+    assert document["tracks"][0]["output"]["size_bytes"] == destination.stat().st_size
+    assert document["tracks"][0]["format"]["container"] == "mov,mp4,m4a,3gp,3g2,mj2"
+    video_stream = next(
+        stream for stream in document["tracks"][0]["streams"] if stream["type"] == "video"
+    )
+    assert video_stream["codec"] == "h264"
+    assert document["tools"]["ffmpeg"].startswith("ffmpeg version test")
+    assert document["tools"]["ffprobe"].startswith("ffprobe version test")
+
+
+def test_build_metadata_document_without_ffprobe(tmp_path: Path) -> None:
+    title = TitleInfo(label="Episode", duration=timedelta(minutes=42))
+    disc = DiscInfo(label="Series Disc", titles=(title,))
+    classification = ClassificationResult("series", (title,), ("s01e01",))
+
+    destination = tmp_path / "series" / "series_track01.mp4"
+    plan = RipPlan(
+        device="/dev/sr0",
+        title=title,
+        destination=destination,
+        command=("ffmpeg", "-i", "/dev/sr0", str(destination)),
+        will_execute=True,
+    )
+
+    document = build_metadata_document(
+        disc,
+        classification,
+        (plan,),
+        config={},
+        which=lambda _name: None,
+        ffprobe_runner=_fake_version_runner,
+        version_runner=_fake_version_runner,
+        now=lambda: datetime(2024, 6, 1, tzinfo=timezone.utc),
+    )
+
+    track = document["tracks"][0]
+    assert track["streams"] == []
+    assert track["output"]["exists"] is False
+    assert document["tools"]["ffmpeg"].startswith("ffmpeg version test")
+
+
+def test_write_metadata_document_persists_json(tmp_path: Path) -> None:
+    document = {
+        "generated_at": datetime(2024, 1, 1, tzinfo=timezone.utc).isoformat(),
+        "disc": {"label": "Sample", "id": None},
+        "classification": {"type": "movie", "episode_count": 1},
+        "title": "Sample",
+        "output_root": str(tmp_path),
+        "tools": {},
+        "tracks": [],
+    }
+
+    path = write_metadata_document(document, tmp_path)
+
+    assert path.name == "metadata.json"
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    assert loaded == document


### PR DESCRIPTION
## Summary
- add a `metadata_json` helper that collects disc, track, stream, and tool information (via `ffprobe` when available) and writes it to `metadata.json`.【F:src/discripper/core/metadata_json.py†L241-L328】
- invoke the metadata exporter from the CLI after successful rips while skipping dry-run executions and logging the emitted file path.【F:src/discripper/cli.py†L192-L240】【F:src/discripper/cli.py†L459-L466】
- cover the new exporter with targeted tests, extend CLI tests to assert metadata emission, document the schema, and mark #PX-T3 complete.【F:tests/test_metadata_json.py†L14-L142】【F:tests/test_cli.py†L35-L148】【F:tests/test_cli.py†L583-L606】【F:docs/metadata-schema.md†L1-L107】【F:TASKS.md†L135-L143】

## Testing
- `pip install -e .`【f8c72d†L1-L21】
- `pip install -e .[dev]`【81d9cf†L1-L22】
- `ruff check .`【601f9b†L1-L2】
- `pytest` (pyproject `addopts` adds `-q --cov=src --cov-fail-under=80`)【4d7511†L1-L21】

------
https://chatgpt.com/codex/tasks/task_b_68e48b2555908321823fe4180284a60c