### PR TITLE
PX-T4: Wire CLI title flow through pipeline

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -142,7 +142,7 @@
     - When multiple tracks are produced, each appears with accurate properties.
     - Command exits non-error even if some non-critical fields are unavailable (fields may be null).
 
-- [ ] Wire CLI → core → ripper → post-processing [#PX-T4]
+- [x] Wire CLI → core → ripper → post-processing [#PX-T4]
   - **Description:** Ensure the title flag flows end-to-end so naming and metadata generation have access to it; centralize naming util.
   - **Acceptance Criteria:**
     - Single source-of-truth function for slug + path building.

--- a/src/discripper/core/__init__.py
+++ b/src/discripper/core/__init__.py
@@ -31,7 +31,13 @@ from .metadata import (
     MetadataProvider,
     NullMetadataProvider,
 )
-from .naming import movie_output_path, sanitize_component, series_output_path
+from .naming import (
+    TITLE_SOURCE_KEY,
+    movie_output_path,
+    sanitize_component,
+    select_disc_title,
+    series_output_path,
+)
 from .rip import RipExecutionError, RipPlan, rip_disc, rip_title, run_rip_plan
 
 __all__ = [
@@ -58,8 +64,10 @@ __all__ = [
     "NullMetadataProvider",
     "DEFAULT_METADATA_PROVIDER",
     "sanitize_component",
+    "select_disc_title",
     "movie_output_path",
     "series_output_path",
+    "TITLE_SOURCE_KEY",
     "RipExecutionError",
     "RipPlan",
     "rip_disc",


### PR DESCRIPTION
## Summary
- centralize disc title selection in the naming helpers and export the provenance constant through the core package
- update the CLI configuration resolution to normalize titles, track their source, and propagate the selected title for logging and metadata
- add regression tests for CLI provenance handling and naming-based title selection fallbacks

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e48eebe1088321b42dca51228dfb4e