### PR TITLE
#PX-T5 Audit config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ in YAML terms—strings may include `~` for home-directory expansion.
 | `naming.separator` | string | Separator inserted between filename segments. |
 | `naming.lowercase` | boolean | When true, lowercase all generated paths. |
 | `naming.episode_title_strategy` | string | Episode title inference strategy (`label`, `episode-number`, or `module:callable`). |
+| `naming.disc_directory_pattern` | string | Pattern for the directory that contains rip artifacts (`{slug}` by default). |
+| `naming.track_filename_pattern` | string | Pattern for individual track filenames (`{slug}_track{index:02d}{extension}` by default). |
+| `metadata.placement` | string | Where to place `metadata.json` (`title-directory` or `output-root`). |
+| `metadata.directory` | string or null | Absolute path override for metadata output (`null` to disable). |
 | `logging.level` | string or integer | Logging level (e.g. `INFO`, `DEBUG`, or `20`). |
 
 The `naming.episode_title_strategy` option controls how episode names are inferred for
@@ -110,6 +114,10 @@ to verify each setting's default and the available override surface.
 | `naming.separator` | `_` | `naming.separator` | — | Filename segment joiner. |
 | `naming.lowercase` | `false` | `naming.lowercase` | — | Lowercases destination paths. |
 | `naming.episode_title_strategy` | `label` | `naming.episode_title_strategy` | — | Selects episode naming strategy. |
+| `naming.disc_directory_pattern` | `{slug}` | `naming.disc_directory_pattern` | — | Supports `{slug}`, `{index}`, `{extension}`, `{ext}` placeholders. |
+| `naming.track_filename_pattern` | `{slug}_track{index:02d}{extension}` | `naming.track_filename_pattern` | — | Customize filename structure (same placeholders as above). |
+| `metadata.placement` | `title-directory` | `metadata.placement` | — | Set to `output-root` to write metadata beside the configured output directory. |
+| `metadata.directory` | `None` | `metadata.directory` | — | Absolute directory override for metadata documents. |
 | `logging.level` | `INFO` | `logging.level` | `--verbose` | Flag forces `DEBUG` logging. |
 | `logging.file` | None | `logging.file` | `--log-file` | Optional log file path; leave unset to disable. |
 
@@ -130,6 +138,11 @@ naming:
   separator: _
   lowercase: false
   episode_title_strategy: label
+  disc_directory_pattern: "{slug}"
+  track_filename_pattern: "{slug}_track{index:02d}{extension}"
+metadata:
+  placement: title-directory
+  directory: null
 logging:
   level: INFO
   file: null
@@ -140,6 +153,12 @@ When `compression` is set to `true` the CLI logs a ready-to-run
 command automatically; it simply assembles a safe default that you can copy
 once the rip completes. Leave the option at its default of `false` to skip
 generating the compression plans.
+
+Use the `naming` patterns to reshape the directory and filename layout while
+keeping deterministic slugs. The placeholders `{slug}`, `{index}`,
+`{extension}`, and `{ext}` are available inside both patterns. To relocate
+metadata away from the title directory, set `metadata.placement` to
+`output-root` or point `metadata.directory` at an absolute path.
 
 Set `logging.file` to a writable path—or pass `--log-file` on the CLI—to mirror
 console output into a persistent log file.

--- a/TASKS.md
+++ b/TASKS.md
@@ -148,7 +148,7 @@
     - Single source-of-truth function for slug + path building.
     - No duplicate logic across modules (unit covered).
 
-- [ ] Config & defaults audit [#PX-T5]
+- [x] Config & defaults audit [#PX-T5]
   - **Description:** Add/confirm config keys in `{CONFIG_PATH}` that influence output root, metadata placement, and naming pattern overrides.
   - **Acceptance Criteria:**
     - Default behavior matches above when no overrides present.

--- a/src/discripper/config.py
+++ b/src/discripper/config.py
@@ -25,6 +25,12 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "separator": "_",
         "lowercase": False,
         "episode_title_strategy": "label",
+        "disc_directory_pattern": "{slug}",
+        "track_filename_pattern": "{slug}_track{index:02d}{extension}",
+    },
+    "metadata": {
+        "placement": "title-directory",
+        "directory": None,
     },
     "logging": {
         "level": "INFO",
@@ -47,6 +53,12 @@ CONFIG_SCHEMA: dict[str, Any] = {
         "separator": str,
         "lowercase": bool,
         "episode_title_strategy": str,
+        "disc_directory_pattern": str,
+        "track_filename_pattern": str,
+    },
+    "metadata": {
+        "placement": str,
+        "directory": (str, type(None)),
     },
     "logging": {
         "level": (str, int),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,6 +150,46 @@ def _install_movie_pipeline(
     return events
 
 
+def test_metadata_directory_for_plans_respects_override(tmp_path: Path) -> None:
+    title = TitleInfo(label="Feature", duration=timedelta(minutes=90))
+    destination = tmp_path / "slug" / "slug_track01.mp4"
+    plan = RipPlan(
+        device="/dev/sr0",
+        title=title,
+        destination=destination,
+        command=("echo",),
+        will_execute=True,
+    )
+    config = copy.deepcopy(config_module.DEFAULT_CONFIG)
+    override_dir = tmp_path / "metadata"
+    config["metadata"]["directory"] = str(override_dir)
+
+    directory = cli._metadata_directory_for_plans((plan,), config)
+
+    assert directory == override_dir
+
+
+def test_metadata_directory_for_plans_honors_output_root(tmp_path: Path) -> None:
+    title = TitleInfo(label="Feature", duration=timedelta(minutes=90))
+    destination = tmp_path / "slug" / "slug_track01.mp4"
+    plan = RipPlan(
+        device="/dev/sr0",
+        title=title,
+        destination=destination,
+        command=("echo",),
+        will_execute=True,
+    )
+    config = copy.deepcopy(config_module.DEFAULT_CONFIG)
+    output_root = tmp_path / "library"
+    config["output_directory"] = str(output_root)
+    config["metadata"]["directory"] = None
+    config["metadata"]["placement"] = "output-root"
+
+    directory = cli._metadata_directory_for_plans((plan,), config)
+
+    assert directory == output_root
+
+
 def _install_series_pipeline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     events: list[object] = []
     title_one = TitleInfo(label="Episode One", duration=timedelta(minutes=44))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,3 +63,24 @@ def test_load_config_validates_nested_schema(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="naming"):
         config.load_config(config_file)
+
+
+def test_load_config_overrides_metadata_and_patterns(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "metadata:\n"
+        "  placement: output-root\n"
+        "  directory: ~/Media/discripper\n"
+        "naming:\n"
+        "  track_filename_pattern: '{slug}-{index:02d}.{ext}'\n",
+        encoding="utf-8",
+    )
+
+    loaded = config.load_config(config_file)
+
+    assert loaded["metadata"]["placement"] == "output-root"
+    assert loaded["metadata"]["directory"] == "~/Media/discripper"
+    assert (
+        loaded["naming"]["track_filename_pattern"]
+        == "{slug}-{index:02d}.{ext}"
+    )

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,6 +1,8 @@
+from copy import deepcopy
 from datetime import timedelta
 from pathlib import Path
 
+from discripper import config as config_module
 from discripper.core import (
     DiscInfo,
     TitleInfo,
@@ -124,6 +126,19 @@ def test_series_output_path_adds_suffix_when_collision(tmp_path: Path) -> None:
 
     second = series_output_path("Example Show", title, "s01e01", config)
     assert second == tmp_path / "example-show" / "example-show_track01_1.mp4"
+
+
+def test_movie_output_path_honors_custom_patterns(tmp_path: Path) -> None:
+    title = TitleInfo(label="The Matrix", duration=timedelta(minutes=136))
+    config = deepcopy(config_module.DEFAULT_CONFIG)
+    config["output_directory"] = str(tmp_path)
+    config["naming"]["disc_directory_pattern"] = "custom/{slug}"
+    config["naming"]["track_filename_pattern"] = "{slug}-{index:03d}.{ext}"
+
+    path = movie_output_path(title, config, track_index=5)
+
+    expected = tmp_path / "custom" / "the-matrix" / "the-matrix-005.mp4"
+    assert path == expected
 
 
 def test_select_disc_title_prefers_cli_override() -> None:


### PR DESCRIPTION
## Summary
- add naming pattern and metadata placement overrides to the default configuration and schema validation
- respect metadata directory/placement overrides when writing metadata json and when generating output paths
- document the new configuration keys and cover them with focused tests

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

------
https://chatgpt.com/codex/tasks/task_b_68e492f8d38c8321a93eb2395ebccd17