### PR TITLE
Add tests for CLI naming and metadata JSON [#PX-T6]

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -154,7 +154,7 @@
     - Default behavior matches above when no overrides present.
     - Overrides documented in `project_spec.md` (if present) or `README.md`.
 
-- [ ] Tests for CLI, naming, and metadata JSON [#PX-T6]
+- [x] Tests for CLI, naming, and metadata JSON [#PX-T6]
   - **Description:** Add unit tests for slug rules, filename rendering, and JSON writer; add at least one integration-style test that mocks a rip result.
   - **Acceptance Criteria:**
     - Tests run locally and in CI; cover error handling (no title, invalid title, missing metadata fields).


### PR DESCRIPTION
## Summary
- add naming slug fallback and invalid-pattern coverage to title-aware path helpers
- extend metadata JSON tests to cover sparse ffprobe data and directory creation
- add CLI integration test exercising metadata emission and mark the roadmap task complete

## Testing
- pip install -e .
- pip install -e .[dev]
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

------
https://chatgpt.com/codex/tasks/task_b_68e4a2477e7c8321a68343757097a700